### PR TITLE
pgRouting 3

### DIFF
--- a/10-2.5-develop/Dockerfile
+++ b/10-2.5-develop/Dockerfile
@@ -3,7 +3,7 @@ FROM postgis/postgis:10-2.5
 LABEL maintainer="pgRouting Project - https://pgrouting.net"
 
 ENV PGROUTING_VERSION develop
-ENV PGROUTING_GIT_HASH d93c618ae9c2c57885c8a52287ae226ee7b9a4a4
+ENV PGROUTING_GIT_HASH 04fb4baceeebcbe4a4aeaf13d34ec995c584a910
 
 RUN apt update \
  && apt install -y \

--- a/10-2.5-master/Dockerfile
+++ b/10-2.5-master/Dockerfile
@@ -3,7 +3,7 @@ FROM postgis/postgis:10-2.5
 LABEL maintainer="pgRouting Project - https://pgrouting.net"
 
 ENV PGROUTING_VERSION master
-ENV PGROUTING_GIT_HASH 017483bbe3aae791e4fe702d79fc524077db3147
+ENV PGROUTING_GIT_HASH f4de22fe895574fcb3da4d33747c6eb030ae989a
 
 RUN apt update \
  && apt install -y \

--- a/11-2.5-develop/Dockerfile
+++ b/11-2.5-develop/Dockerfile
@@ -3,7 +3,7 @@ FROM postgis/postgis:11-2.5
 LABEL maintainer="pgRouting Project - https://pgrouting.net"
 
 ENV PGROUTING_VERSION develop
-ENV PGROUTING_GIT_HASH d93c618ae9c2c57885c8a52287ae226ee7b9a4a4
+ENV PGROUTING_GIT_HASH 04fb4baceeebcbe4a4aeaf13d34ec995c584a910
 
 RUN apt update \
  && apt install -y \

--- a/11-2.5-master/Dockerfile
+++ b/11-2.5-master/Dockerfile
@@ -3,7 +3,7 @@ FROM postgis/postgis:11-2.5
 LABEL maintainer="pgRouting Project - https://pgrouting.net"
 
 ENV PGROUTING_VERSION master
-ENV PGROUTING_GIT_HASH 017483bbe3aae791e4fe702d79fc524077db3147
+ENV PGROUTING_GIT_HASH f4de22fe895574fcb3da4d33747c6eb030ae989a
 
 RUN apt update \
  && apt install -y \

--- a/11-3.0-3.0.0/Dockerfile
+++ b/11-3.0-3.0.0/Dockerfile
@@ -1,0 +1,54 @@
+FROM postgis/postgis:11-3.0
+
+LABEL maintainer="pgRouting Project - https://pgrouting.net"
+
+ENV PGROUTING_VERSION 3.0.0
+ENV PGROUTING_SHA256 eecb6a634b7bfdba0640518053a514330d468d214a8225548917fbce8a41745f
+
+RUN set -ex \
+ && apt update \
+ && apt install -y \
+        libboost-atomic1.62.0 \
+        libboost-chrono1.62.0 \
+        libboost-graph1.62.0 \
+        libboost-date-time1.62.0 \
+        libboost-program-options1.62.0 \
+        libboost-system1.62.0 \
+        libboost-thread1.62.0 \
+        libcgal12 \
+ && apt install -y \
+        build-essential \
+        cmake \
+        wget \
+        libboost-graph-dev \
+        libcgal-dev \
+        libpq-dev \
+        postgresql-server-dev-${PG_MAJOR} \
+ && wget -O pgrouting.tar.gz "https://github.com/pgRouting/pgrouting/archive/v${PGROUTING_VERSION}.tar.gz" \
+ && echo "$PGROUTING_SHA256 *pgrouting.tar.gz" | sha256sum -c - \
+ && mkdir -p /usr/src/pgrouting \
+ && tar \
+        --extract \
+        --file pgrouting.tar.gz \
+        --directory /usr/src/pgrouting \
+        --strip-components 1 \
+ && rm pgrouting.tar.gz \
+ && cd /usr/src/pgrouting \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd / \
+ && rm -rf /usr/src/pgrouting \
+ && apt-mark manual postgresql-11 \
+ && apt purge -y --autoremove \
+        build-essential \
+        cmake \
+        wget \
+        libcgal-dev \
+        libpq-dev \
+        libboost-graph-dev \
+        postgresql-server-dev-${PG_MAJOR} \
+ && rm -rf /var/lib/apt/lists/*
+RUN rm /docker-entrypoint-initdb.d/postgis.sh

--- a/11-3.0-3.0.0/README.md
+++ b/11-3.0-3.0.0/README.md
@@ -1,0 +1,3 @@
+# pgRouting 3.0.0 (pg11)
+
+pgRouting Docker image (version 3.0.0) built over [Postgres 11/PostGIS 3.0](https://hub.docker.com/r/postgis/postgis) and dependencies.

--- a/11-3.0-3.0.0/docker-compose.yml
+++ b/11-3.0-3.0.0/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3"
+services:
+  postgis:
+    image: pgrouting/pgrouting:11-3.0-3.0.0
+    ports:
+      - "5432:5432"
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_PASSWORD=postgres
+volumes:
+  db-data:

--- a/11-3.0-3.0.0/extra/Dockerfile
+++ b/11-3.0-3.0.0/extra/Dockerfile
@@ -1,0 +1,44 @@
+FROM pgrouting/pgrouting:11-3.0-3.0.0
+
+ENV OSM2PGROUTING_VERSION 2.3.6
+
+RUN apt update \
+ && apt install -y \
+        libpqxx-4.0v5 \
+ && apt install -y \
+        build-essential \
+        cmake \
+        wget \
+        libboost-program-options-dev \
+        libexpat1 \
+        libexpat-dev \
+        libosmium2-dev \
+        libpqxx-dev \
+        zlib1g-dev \
+ && cd /usr/local/src \
+ && wget https://github.com/pgRouting/osm2pgrouting/archive/v${OSM2PGROUTING_VERSION}.tar.gz \
+ && tar xvf v${OSM2PGROUTING_VERSION}.tar.gz \
+ && cd osm2pgrouting-${OSM2PGROUTING_VERSION} \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd ../tools/osmium/ \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd /usr/local/src \
+ && rm -rf ./* \
+ && apt purge -y --autoremove \
+        build-essential \
+        cmake \
+        wget \
+        libexpat-dev \
+        libosmium2-dev \
+        libpqxx-dev \
+        zlib1g-dev \
+ && apt autoremove -y \
+ && rm -rf /var/lib/apt/lists/*

--- a/12-3.0-3.0.0/Dockerfile
+++ b/12-3.0-3.0.0/Dockerfile
@@ -1,0 +1,54 @@
+FROM postgis/postgis:12-3.0
+
+LABEL maintainer="pgRouting Project - https://pgrouting.net"
+
+ENV PGROUTING_VERSION 3.0.0
+ENV PGROUTING_SHA256 eecb6a634b7bfdba0640518053a514330d468d214a8225548917fbce8a41745f
+
+RUN set -ex \
+ && apt update \
+ && apt install -y \
+        libboost-atomic1.67.0 \
+        libboost-chrono1.67.0 \
+        libboost-graph1.67.0 \
+        libboost-date-time1.67.0 \
+        libboost-program-options1.67.0 \
+        libboost-system1.67.0 \
+        libboost-thread1.67.0 \
+        libcgal13 \
+ && apt install -y \
+        build-essential \
+        cmake \
+        wget \
+        libboost-graph-dev \
+        libcgal-dev \
+        libpq-dev \
+        postgresql-server-dev-${PG_MAJOR} \
+ && wget -O pgrouting.tar.gz "https://github.com/pgRouting/pgrouting/archive/v${PGROUTING_VERSION}.tar.gz" \
+ && echo "$PGROUTING_SHA256 *pgrouting.tar.gz" | sha256sum -c - \
+ && mkdir -p /usr/src/pgrouting \
+ && tar \
+        --extract \
+        --file pgrouting.tar.gz \
+        --directory /usr/src/pgrouting \
+        --strip-components 1 \
+ && rm pgrouting.tar.gz \
+ && cd /usr/src/pgrouting \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd / \
+ && rm -rf /usr/src/pgrouting \
+ && apt-mark manual postgresql-12 \
+ && apt purge -y --autoremove \
+        build-essential \
+        cmake \
+        wget \
+        libcgal-dev \
+        libpq-dev \
+        libboost-graph-dev \
+        postgresql-server-dev-${PG_MAJOR} \
+ && rm -rf /var/lib/apt/lists/*
+RUN rm /docker-entrypoint-initdb.d/postgis.sh

--- a/12-3.0-3.0.0/README.md
+++ b/12-3.0-3.0.0/README.md
@@ -1,0 +1,3 @@
+# pgRouting 3.0.0 (pg12)
+
+pgRouting Docker image (version 3.0.0) built over [Postgres 12/PostGIS 3.0](https://hub.docker.com/r/postgis/postgis) and dependencies.

--- a/12-3.0-3.0.0/docker-compose.yml
+++ b/12-3.0-3.0.0/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3"
+services:
+  postgis:
+    image: pgrouting/pgrouting:12-3.0-3.0.0
+    ports:
+      - "5432:5432"
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_PASSWORD=postgres
+volumes:
+  db-data:

--- a/12-3.0-3.0.0/extra/Dockerfile
+++ b/12-3.0-3.0.0/extra/Dockerfile
@@ -1,0 +1,44 @@
+FROM pgrouting/pgrouting:12-3.0-3.0.0
+
+ENV OSM2PGROUTING_VERSION 2.3.6
+
+RUN apt update \
+ && apt install -y \
+        libpqxx-6.2 \
+ && apt install -y \
+        build-essential \
+        cmake \
+        wget \
+        libboost-program-options-dev \
+        libexpat1 \
+        libexpat-dev \
+        libosmium2-dev \
+        libpqxx-dev \
+        zlib1g-dev \
+ && cd /usr/local/src \
+ && wget https://github.com/pgRouting/osm2pgrouting/archive/v${OSM2PGROUTING_VERSION}.tar.gz \
+ && tar xvf v${OSM2PGROUTING_VERSION}.tar.gz \
+ && cd osm2pgrouting-${OSM2PGROUTING_VERSION} \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd ../tools/osmium/ \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd /usr/local/src \
+ && rm -rf ./* \
+ && apt purge -y --autoremove \
+        build-essential \
+        cmake \
+        wget \
+        libexpat-dev \
+        libosmium2-dev \
+        libpqxx-dev \
+        zlib1g-dev \
+ && apt autoremove -y \
+ && rm -rf /var/lib/apt/lists/*

--- a/12-3.0-develop/Dockerfile
+++ b/12-3.0-develop/Dockerfile
@@ -3,7 +3,7 @@ FROM postgis/postgis:12-3.0
 LABEL maintainer="pgRouting Project - https://pgrouting.net"
 
 ENV PGROUTING_VERSION develop
-ENV PGROUTING_GIT_HASH d93c618ae9c2c57885c8a52287ae226ee7b9a4a4
+ENV PGROUTING_GIT_HASH 04fb4baceeebcbe4a4aeaf13d34ec995c584a910
 
 RUN apt update \
  && apt install -y \

--- a/12-3.0-master/Dockerfile
+++ b/12-3.0-master/Dockerfile
@@ -3,7 +3,7 @@ FROM postgis/postgis:12-3.0
 LABEL maintainer="pgRouting Project - https://pgrouting.net"
 
 ENV PGROUTING_VERSION master
-ENV PGROUTING_GIT_HASH 017483bbe3aae791e4fe702d79fc524077db3147
+ENV PGROUTING_GIT_HASH f4de22fe895574fcb3da4d33747c6eb030ae989a
 
 RUN apt update \
  && apt install -y \

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ There are several versions available:
 - [2.6.3 with Postgres 10 + PostGIS 2.5](10-2.5-2.6.3/). Docker image: `pgrouting/pgrouting:10-2.5-2.6.3`
 - [2.6.3 with Postgres 11 + PostGIS 2.5](11-2.5-2.6.3/). Docker image: `pgrouting/pgrouting:11-2.5-2.6.3`
 - [2.6.3 with Postgres 12 + PostGIS 3.0](12-3.0-2.6.3/). Docker image: `pgrouting/pgrouting:12-3.0-2.6.3`
+- [3.0.0 with Postgres 11 + PostGIS 3.0](11-3.0-3.0.0/). Docker image: `pgrouting/pgrouting:11-3.0-3.0.0`
+- [3.0.0 with Postgres 12 + PostGIS 3.0](12-3.0-3.0.0/). Docker image: `pgrouting/pgrouting:12-3.0-3.0.0`
 - [master branch with Postgres 10 + PostGIS 2.5](10-2.5-develop/). Docker image: `pgrouting/pgrouting:10-2.5-master`
 - [master branch with Postgres 11 + PostGIS 2.5](11-2.5-develop/). Docker image: `pgrouting/pgrouting:11-2.5-master`
 - [master branch with Postgres 12 + PostGIS 3.0](12-3.0-develop/). Docker image: `pgrouting/pgrouting:12-3.0-master`


### PR DESCRIPTION
Fixes #26  .

Changes proposed in this pull request:
- Added pgRouting v3.0.0 with pg11 and pg12 (not pg10).
- Updated PGROUTING_SHA256 in branch versions (master and develop) using `updated.sh` script 

@pgRouting/admins
