### PR TITLE
Add pgRouting 3.3.2, 3.2.2, 3.1.4, 3.0.6, postgresql-14 and upgrade osm2pgrouting to 2.3.8

### DIFF
--- a/10-2.5-2.6.1/extra/Dockerfile
+++ b/10-2.5-2.6.1/extra/Dockerfile
@@ -1,6 +1,6 @@
 FROM pgrouting/pgrouting:10-2.5-2.6.1
 
-ENV OSM2PGROUTING_VERSION 2.3.7
+ENV OSM2PGROUTING_VERSION 2.3.8
 
 RUN apt update \
  && apt install -y \

--- a/10-2.5-2.6.2/extra/Dockerfile
+++ b/10-2.5-2.6.2/extra/Dockerfile
@@ -1,6 +1,6 @@
 FROM pgrouting/pgrouting:10-2.5-2.6.2
 
-ENV OSM2PGROUTING_VERSION 2.3.7
+ENV OSM2PGROUTING_VERSION 2.3.8
 
 RUN apt update \
  && apt install -y \

--- a/10-2.5-2.6.3/extra/Dockerfile
+++ b/10-2.5-2.6.3/extra/Dockerfile
@@ -1,6 +1,6 @@
 FROM pgrouting/pgrouting:10-2.5-2.6.3
 
-ENV OSM2PGROUTING_VERSION 2.3.7
+ENV OSM2PGROUTING_VERSION 2.3.8
 
 RUN apt update \
  && apt install -y \

--- a/10-2.5-develop/extra/Dockerfile
+++ b/10-2.5-develop/extra/Dockerfile
@@ -1,6 +1,6 @@
 FROM pgrouting/pgrouting:10-2.5-develop
 
-ENV OSM2PGROUTING_VERSION 2.3.7
+ENV OSM2PGROUTING_VERSION 2.3.8
 
 RUN apt update \
  && apt install -y \

--- a/10-2.5-main/Dockerfile
+++ b/10-2.5-main/Dockerfile
@@ -1,20 +1,20 @@
-FROM postgis/postgis:13-3.0
+FROM postgis/postgis:10-2.5
 
 LABEL maintainer="pgRouting Project - https://pgrouting.net"
 
-ENV PGROUTING_VERSION master
-ENV PGROUTING_GIT_HASH 
+ENV PGROUTING_VERSION main
+ENV PGROUTING_GIT_HASH
 
 RUN apt update \
  && apt install -y \
-        libboost-atomic1.67.0 \
-        libboost-chrono1.67.0 \
-        libboost-graph1.67.0 \
-        libboost-date-time1.67.0 \
-        libboost-program-options1.67.0 \
-        libboost-system1.67.0 \
-        libboost-thread1.67.0 \
-        libcgal13 \
+        libboost-atomic1.62.0 \
+        libboost-chrono1.62.0 \
+        libboost-graph1.62.0 \
+        libboost-date-time1.62.0 \
+        libboost-program-options1.62.0 \
+        libboost-system1.62.0 \
+        libboost-thread1.62.0 \
+        libcgal12 \
  && apt install -y \
         build-essential \
         cmake \

--- a/10-2.5-main/README.md
+++ b/10-2.5-main/README.md
@@ -1,0 +1,3 @@
+# pgRouting main (pg10)
+
+pgRouting Docker image (version main) built over [Postgres 10/PostGIS 2.5](https://hub.docker.com/r/postgis/postgis) and dependencies.

--- a/10-2.5-main/docker-compose.yml
+++ b/10-2.5-main/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   postgis:
-    image: pgrouting/pgrouting:11-2.5-master
+    image: pgrouting/pgrouting:10-2.5-main
     ports:
       - "5432:5432"
     volumes:

--- a/10-2.5-main/extra/Dockerfile
+++ b/10-2.5-main/extra/Dockerfile
@@ -1,10 +1,10 @@
-FROM pgrouting/pgrouting:13-3.0-master
+FROM pgrouting/pgrouting:10-2.5-main
 
 ENV OSM2PGROUTING_VERSION 2.3.8
 
 RUN apt update \
  && apt install -y \
-        libpqxx-6.2 \
+        libpqxx-4.0v5 \
  && apt install -y \
         build-essential \
         cmake \

--- a/10-2.5-master/README.md
+++ b/10-2.5-master/README.md
@@ -1,3 +1,0 @@
-# pgRouting master (pg10)
-
-pgRouting Docker image (version master) built over [Postgres 10/PostGIS 2.5](https://hub.docker.com/r/postgis/postgis) and dependencies.

--- a/10-2.5-master/extra/Dockerfile
+++ b/10-2.5-master/extra/Dockerfile
@@ -1,6 +1,6 @@
 FROM pgrouting/pgrouting:10-2.5-master
 
-ENV OSM2PGROUTING_VERSION 2.3.7
+ENV OSM2PGROUTING_VERSION 2.3.8
 
 RUN apt update \
  && apt install -y \

--- a/11-2.5-2.6.1/extra/Dockerfile
+++ b/11-2.5-2.6.1/extra/Dockerfile
@@ -1,6 +1,6 @@
 FROM pgrouting/pgrouting:11-2.5-2.6.1
 
-ENV OSM2PGROUTING_VERSION 2.3.7
+ENV OSM2PGROUTING_VERSION 2.3.8
 
 RUN apt update \
  && apt install -y \

--- a/11-2.5-2.6.2/extra/Dockerfile
+++ b/11-2.5-2.6.2/extra/Dockerfile
@@ -1,6 +1,6 @@
 FROM pgrouting/pgrouting:11-2.5-2.6.2
 
-ENV OSM2PGROUTING_VERSION 2.3.7
+ENV OSM2PGROUTING_VERSION 2.3.8
 
 RUN apt update \
  && apt install -y \

--- a/11-2.5-2.6.3/extra/Dockerfile
+++ b/11-2.5-2.6.3/extra/Dockerfile
@@ -1,6 +1,6 @@
 FROM pgrouting/pgrouting:11-2.5-2.6.3
 
-ENV OSM2PGROUTING_VERSION 2.3.7
+ENV OSM2PGROUTING_VERSION 2.3.8
 
 RUN apt update \
  && apt install -y \

--- a/11-2.5-develop/Dockerfile
+++ b/11-2.5-develop/Dockerfile
@@ -3,7 +3,7 @@ FROM postgis/postgis:11-2.5
 LABEL maintainer="pgRouting Project - https://pgrouting.net"
 
 ENV PGROUTING_VERSION develop
-ENV PGROUTING_GIT_HASH fb48e16f2d3c0f11060d58fc8be36e9325db2f59
+ENV PGROUTING_GIT_HASH 7fcfc858d63fdc6060f9ba22138fbfb247672558
 
 RUN apt update \
  && apt install -y \

--- a/11-2.5-develop/extra/Dockerfile
+++ b/11-2.5-develop/extra/Dockerfile
@@ -1,6 +1,6 @@
 FROM pgrouting/pgrouting:11-2.5-develop
 
-ENV OSM2PGROUTING_VERSION 2.3.7
+ENV OSM2PGROUTING_VERSION 2.3.8
 
 RUN apt update \
  && apt install -y \

--- a/11-2.5-main/Dockerfile
+++ b/11-2.5-main/Dockerfile
@@ -3,7 +3,7 @@ FROM postgis/postgis:11-2.5
 LABEL maintainer="pgRouting Project - https://pgrouting.net"
 
 ENV PGROUTING_VERSION main
-ENV PGROUTING_GIT_HASH
+ENV PGROUTING_GIT_HASH 1d4f0a5c7ae815ff1ed31ae90171825a764dbf72
 
 RUN apt update \
  && apt install -y \

--- a/11-2.5-main/Dockerfile
+++ b/11-2.5-main/Dockerfile
@@ -2,8 +2,8 @@ FROM postgis/postgis:11-2.5
 
 LABEL maintainer="pgRouting Project - https://pgrouting.net"
 
-ENV PGROUTING_VERSION master
-ENV PGROUTING_GIT_HASH 
+ENV PGROUTING_VERSION main
+ENV PGROUTING_GIT_HASH
 
 RUN apt update \
  && apt install -y \

--- a/11-2.5-main/README.md
+++ b/11-2.5-main/README.md
@@ -1,0 +1,3 @@
+# pgRouting main (pg11)
+
+pgRouting Docker image (version main) built over [Postgres 11/PostGIS 2.5](https://hub.docker.com/r/postgis/postgis) and dependencies.

--- a/11-2.5-main/docker-compose.yml
+++ b/11-2.5-main/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   postgis:
-    image: pgrouting/pgrouting:13-3.0-master
+    image: pgrouting/pgrouting:11-2.5-main
     ports:
       - "5432:5432"
     volumes:

--- a/11-2.5-main/extra/Dockerfile
+++ b/11-2.5-main/extra/Dockerfile
@@ -1,4 +1,4 @@
-FROM pgrouting/pgrouting:10-2.5-master
+FROM pgrouting/pgrouting:11-2.5-main
 
 ENV OSM2PGROUTING_VERSION 2.3.8
 

--- a/11-2.5-master/README.md
+++ b/11-2.5-master/README.md
@@ -1,3 +1,0 @@
-# pgRouting master (pg11)
-
-pgRouting Docker image (version master) built over [Postgres 11/PostGIS 2.5](https://hub.docker.com/r/postgis/postgis) and dependencies.

--- a/11-2.5-master/extra/Dockerfile
+++ b/11-2.5-master/extra/Dockerfile
@@ -1,6 +1,6 @@
 FROM pgrouting/pgrouting:11-2.5-master
 
-ENV OSM2PGROUTING_VERSION 2.3.7
+ENV OSM2PGROUTING_VERSION 2.3.8
 
 RUN apt update \
  && apt install -y \

--- a/11-3.0-3.0.0/extra/Dockerfile
+++ b/11-3.0-3.0.0/extra/Dockerfile
@@ -1,6 +1,6 @@
 FROM pgrouting/pgrouting:11-3.0-3.0.0
 
-ENV OSM2PGROUTING_VERSION 2.3.7
+ENV OSM2PGROUTING_VERSION 2.3.8
 
 RUN apt update \
  && apt install -y \

--- a/11-3.0-3.0.1/extra/Dockerfile
+++ b/11-3.0-3.0.1/extra/Dockerfile
@@ -1,6 +1,6 @@
 FROM pgrouting/pgrouting:11-3.0-3.0.1
 
-ENV OSM2PGROUTING_VERSION 2.3.7
+ENV OSM2PGROUTING_VERSION 2.3.8
 
 RUN apt update \
  && apt install -y \

--- a/11-3.0-3.1.0/extra/Dockerfile
+++ b/11-3.0-3.1.0/extra/Dockerfile
@@ -1,6 +1,6 @@
 FROM pgrouting/pgrouting:11-3.0-3.1.0
 
-ENV OSM2PGROUTING_VERSION 2.3.7
+ENV OSM2PGROUTING_VERSION 2.3.8
 
 RUN apt update \
  && apt install -y \

--- a/11-3.0-3.1.1/extra/Dockerfile
+++ b/11-3.0-3.1.1/extra/Dockerfile
@@ -1,6 +1,6 @@
 FROM pgrouting/pgrouting:11-3.0-3.1.1
 
-ENV OSM2PGROUTING_VERSION 2.3.7
+ENV OSM2PGROUTING_VERSION 2.3.8
 
 RUN apt update \
  && apt install -y \

--- a/11-3.1-3.1.3/extra/Dockerfile
+++ b/11-3.1-3.1.3/extra/Dockerfile
@@ -1,6 +1,6 @@
 FROM pgrouting/pgrouting:11-3.1-3.1.3
 
-ENV OSM2PGROUTING_VERSION 2.3.7
+ENV OSM2PGROUTING_VERSION 2.3.8
 
 RUN apt update \
  && apt install -y \

--- a/11-3.1-3.2.0/extra/Dockerfile
+++ b/11-3.1-3.2.0/extra/Dockerfile
@@ -1,6 +1,6 @@
 FROM pgrouting/pgrouting:11-3.1-3.2.0
 
-ENV OSM2PGROUTING_VERSION 2.3.7
+ENV OSM2PGROUTING_VERSION 2.3.8
 
 RUN apt update \
  && apt install -y \

--- a/11-3.1-3.2.1/extra/Dockerfile
+++ b/11-3.1-3.2.1/extra/Dockerfile
@@ -1,6 +1,6 @@
 FROM pgrouting/pgrouting:11-3.1-3.2.1
 
-ENV OSM2PGROUTING_VERSION 2.3.7
+ENV OSM2PGROUTING_VERSION 2.3.8
 
 RUN apt update \
  && apt install -y \

--- a/11-3.2-3.0.6/Dockerfile
+++ b/11-3.2-3.0.6/Dockerfile
@@ -1,0 +1,54 @@
+FROM postgis/postgis:11-3.2
+
+LABEL maintainer="pgRouting Project - https://pgrouting.net"
+
+ENV PGROUTING_VERSION 3.0.6
+ENV PGROUTING_SHA256 9852e1e8f2da9137fb6120acee05dfb8edcff00bf06ff40a61291d91e84c69e9
+
+RUN set -ex \
+ && apt update \
+ && apt install -y \
+        libboost-atomic1.62.0 \
+        libboost-chrono1.62.0 \
+        libboost-graph1.62.0 \
+        libboost-date-time1.62.0 \
+        libboost-program-options1.62.0 \
+        libboost-system1.62.0 \
+        libboost-thread1.62.0 \
+        libcgal12 \
+ && apt install -y \
+        build-essential \
+        cmake \
+        wget \
+        libboost-graph-dev \
+        libcgal-dev \
+        libpq-dev \
+        postgresql-server-dev-${PG_MAJOR} \
+ && wget -O pgrouting.tar.gz "https://github.com/pgRouting/pgrouting/archive/v${PGROUTING_VERSION}.tar.gz" \
+ && echo "$PGROUTING_SHA256 *pgrouting.tar.gz" | sha256sum -c - \
+ && mkdir -p /usr/src/pgrouting \
+ && tar \
+        --extract \
+        --file pgrouting.tar.gz \
+        --directory /usr/src/pgrouting \
+        --strip-components 1 \
+ && rm pgrouting.tar.gz \
+ && cd /usr/src/pgrouting \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd / \
+ && rm -rf /usr/src/pgrouting \
+ && apt-mark manual postgresql-11 \
+ && apt purge -y --autoremove \
+        build-essential \
+        cmake \
+        wget \
+        libcgal-dev \
+        libpq-dev \
+        libboost-graph-dev \
+        postgresql-server-dev-${PG_MAJOR} \
+ && rm -rf /var/lib/apt/lists/*
+RUN rm /docker-entrypoint-initdb.d/10_postgis.sh

--- a/11-3.2-3.0.6/README.md
+++ b/11-3.2-3.0.6/README.md
@@ -1,0 +1,3 @@
+# pgRouting 3.0.6 (pg11)
+
+pgRouting Docker image (version 3.0.6) built over [Postgres 11/PostGIS 3.2](https://hub.docker.com/r/postgis/postgis) and dependencies.

--- a/11-3.2-3.0.6/docker-compose.yml
+++ b/11-3.2-3.0.6/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3"
+services:
+  postgis:
+    image: pgrouting/pgrouting:11-3.2-3.0.6
+    ports:
+      - "5432:5432"
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_PASSWORD=postgres
+volumes:
+  db-data:

--- a/11-3.2-3.0.6/extra/Dockerfile
+++ b/11-3.2-3.0.6/extra/Dockerfile
@@ -1,0 +1,44 @@
+FROM pgrouting/pgrouting:11-3.2-3.0.6
+
+ENV OSM2PGROUTING_VERSION 2.3.8
+
+RUN apt update \
+ && apt install -y \
+        libpqxx-4.0v5 \
+ && apt install -y \
+        build-essential \
+        cmake \
+        wget \
+        libboost-program-options-dev \
+        libexpat1 \
+        libexpat-dev \
+        libosmium2-dev \
+        libpqxx-dev \
+        zlib1g-dev \
+ && cd /usr/local/src \
+ && wget https://github.com/pgRouting/osm2pgrouting/archive/v${OSM2PGROUTING_VERSION}.tar.gz \
+ && tar xvf v${OSM2PGROUTING_VERSION}.tar.gz \
+ && cd osm2pgrouting-${OSM2PGROUTING_VERSION} \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd ../tools/osmium/ \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd /usr/local/src \
+ && rm -rf ./* \
+ && apt purge -y --autoremove \
+        build-essential \
+        cmake \
+        wget \
+        libexpat-dev \
+        libosmium2-dev \
+        libpqxx-dev \
+        zlib1g-dev \
+ && apt autoremove -y \
+ && rm -rf /var/lib/apt/lists/*

--- a/11-3.2-3.1.4/Dockerfile
+++ b/11-3.2-3.1.4/Dockerfile
@@ -1,0 +1,54 @@
+FROM postgis/postgis:11-3.2
+
+LABEL maintainer="pgRouting Project - https://pgrouting.net"
+
+ENV PGROUTING_VERSION 3.1.4
+ENV PGROUTING_SHA256 dcd05817b187e5c3f0cb741148db230a5f8d114b9738b6395057a9473b816842
+
+RUN set -ex \
+ && apt update \
+ && apt install -y \
+        libboost-atomic1.62.0 \
+        libboost-chrono1.62.0 \
+        libboost-graph1.62.0 \
+        libboost-date-time1.62.0 \
+        libboost-program-options1.62.0 \
+        libboost-system1.62.0 \
+        libboost-thread1.62.0 \
+        libcgal12 \
+ && apt install -y \
+        build-essential \
+        cmake \
+        wget \
+        libboost-graph-dev \
+        libcgal-dev \
+        libpq-dev \
+        postgresql-server-dev-${PG_MAJOR} \
+ && wget -O pgrouting.tar.gz "https://github.com/pgRouting/pgrouting/archive/v${PGROUTING_VERSION}.tar.gz" \
+ && echo "$PGROUTING_SHA256 *pgrouting.tar.gz" | sha256sum -c - \
+ && mkdir -p /usr/src/pgrouting \
+ && tar \
+        --extract \
+        --file pgrouting.tar.gz \
+        --directory /usr/src/pgrouting \
+        --strip-components 1 \
+ && rm pgrouting.tar.gz \
+ && cd /usr/src/pgrouting \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd / \
+ && rm -rf /usr/src/pgrouting \
+ && apt-mark manual postgresql-11 \
+ && apt purge -y --autoremove \
+        build-essential \
+        cmake \
+        wget \
+        libcgal-dev \
+        libpq-dev \
+        libboost-graph-dev \
+        postgresql-server-dev-${PG_MAJOR} \
+ && rm -rf /var/lib/apt/lists/*
+RUN rm /docker-entrypoint-initdb.d/10_postgis.sh

--- a/11-3.2-3.1.4/README.md
+++ b/11-3.2-3.1.4/README.md
@@ -1,0 +1,3 @@
+# pgRouting 3.1.4 (pg11)
+
+pgRouting Docker image (version 3.1.4) built over [Postgres 11/PostGIS 3.2](https://hub.docker.com/r/postgis/postgis) and dependencies.

--- a/11-3.2-3.1.4/docker-compose.yml
+++ b/11-3.2-3.1.4/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3"
+services:
+  postgis:
+    image: pgrouting/pgrouting:11-3.2-3.1.4
+    ports:
+      - "5432:5432"
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_PASSWORD=postgres
+volumes:
+  db-data:

--- a/11-3.2-3.1.4/extra/Dockerfile
+++ b/11-3.2-3.1.4/extra/Dockerfile
@@ -1,0 +1,44 @@
+FROM pgrouting/pgrouting:11-3.2-3.1.4
+
+ENV OSM2PGROUTING_VERSION 2.3.8
+
+RUN apt update \
+ && apt install -y \
+        libpqxx-4.0v5 \
+ && apt install -y \
+        build-essential \
+        cmake \
+        wget \
+        libboost-program-options-dev \
+        libexpat1 \
+        libexpat-dev \
+        libosmium2-dev \
+        libpqxx-dev \
+        zlib1g-dev \
+ && cd /usr/local/src \
+ && wget https://github.com/pgRouting/osm2pgrouting/archive/v${OSM2PGROUTING_VERSION}.tar.gz \
+ && tar xvf v${OSM2PGROUTING_VERSION}.tar.gz \
+ && cd osm2pgrouting-${OSM2PGROUTING_VERSION} \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd ../tools/osmium/ \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd /usr/local/src \
+ && rm -rf ./* \
+ && apt purge -y --autoremove \
+        build-essential \
+        cmake \
+        wget \
+        libexpat-dev \
+        libosmium2-dev \
+        libpqxx-dev \
+        zlib1g-dev \
+ && apt autoremove -y \
+ && rm -rf /var/lib/apt/lists/*

--- a/11-3.2-3.2.2/Dockerfile
+++ b/11-3.2-3.2.2/Dockerfile
@@ -1,0 +1,54 @@
+FROM postgis/postgis:11-3.2
+
+LABEL maintainer="pgRouting Project - https://pgrouting.net"
+
+ENV PGROUTING_VERSION 3.2.2
+ENV PGROUTING_SHA256 40f67ab944b5a7d91d4eb610cba3ed34a83daf51bb569c75b582f8e88efb72de
+
+RUN set -ex \
+ && apt update \
+ && apt install -y \
+        libboost-atomic1.62.0 \
+        libboost-chrono1.62.0 \
+        libboost-graph1.62.0 \
+        libboost-date-time1.62.0 \
+        libboost-program-options1.62.0 \
+        libboost-system1.62.0 \
+        libboost-thread1.62.0 \
+        libcgal12 \
+ && apt install -y \
+        build-essential \
+        cmake \
+        wget \
+        libboost-graph-dev \
+        libcgal-dev \
+        libpq-dev \
+        postgresql-server-dev-${PG_MAJOR} \
+ && wget -O pgrouting.tar.gz "https://github.com/pgRouting/pgrouting/archive/v${PGROUTING_VERSION}.tar.gz" \
+ && echo "$PGROUTING_SHA256 *pgrouting.tar.gz" | sha256sum -c - \
+ && mkdir -p /usr/src/pgrouting \
+ && tar \
+        --extract \
+        --file pgrouting.tar.gz \
+        --directory /usr/src/pgrouting \
+        --strip-components 1 \
+ && rm pgrouting.tar.gz \
+ && cd /usr/src/pgrouting \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd / \
+ && rm -rf /usr/src/pgrouting \
+ && apt-mark manual postgresql-11 \
+ && apt purge -y --autoremove \
+        build-essential \
+        cmake \
+        wget \
+        libcgal-dev \
+        libpq-dev \
+        libboost-graph-dev \
+        postgresql-server-dev-${PG_MAJOR} \
+ && rm -rf /var/lib/apt/lists/*
+RUN rm /docker-entrypoint-initdb.d/10_postgis.sh

--- a/11-3.2-3.2.2/README.md
+++ b/11-3.2-3.2.2/README.md
@@ -1,0 +1,3 @@
+# pgRouting 3.2.2 (pg11)
+
+pgRouting Docker image (version 3.2.2) built over [Postgres 11/PostGIS 3.2](https://hub.docker.com/r/postgis/postgis) and dependencies.

--- a/11-3.2-3.2.2/docker-compose.yml
+++ b/11-3.2-3.2.2/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3"
+services:
+  postgis:
+    image: pgrouting/pgrouting:11-3.2-3.2.2
+    ports:
+      - "5432:5432"
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_PASSWORD=postgres
+volumes:
+  db-data:

--- a/11-3.2-3.2.2/extra/Dockerfile
+++ b/11-3.2-3.2.2/extra/Dockerfile
@@ -1,0 +1,44 @@
+FROM pgrouting/pgrouting:11-3.2-3.2.2
+
+ENV OSM2PGROUTING_VERSION 2.3.8
+
+RUN apt update \
+ && apt install -y \
+        libpqxx-4.0v5 \
+ && apt install -y \
+        build-essential \
+        cmake \
+        wget \
+        libboost-program-options-dev \
+        libexpat1 \
+        libexpat-dev \
+        libosmium2-dev \
+        libpqxx-dev \
+        zlib1g-dev \
+ && cd /usr/local/src \
+ && wget https://github.com/pgRouting/osm2pgrouting/archive/v${OSM2PGROUTING_VERSION}.tar.gz \
+ && tar xvf v${OSM2PGROUTING_VERSION}.tar.gz \
+ && cd osm2pgrouting-${OSM2PGROUTING_VERSION} \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd ../tools/osmium/ \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd /usr/local/src \
+ && rm -rf ./* \
+ && apt purge -y --autoremove \
+        build-essential \
+        cmake \
+        wget \
+        libexpat-dev \
+        libosmium2-dev \
+        libpqxx-dev \
+        zlib1g-dev \
+ && apt autoremove -y \
+ && rm -rf /var/lib/apt/lists/*

--- a/11-3.2-3.3.2/Dockerfile
+++ b/11-3.2-3.3.2/Dockerfile
@@ -1,0 +1,54 @@
+FROM postgis/postgis:11-3.2
+
+LABEL maintainer="pgRouting Project - https://pgrouting.net"
+
+ENV PGROUTING_VERSION 3.3.2
+ENV PGROUTING_SHA256 d5558cd419c8d46bdc958064cb97f963d1ea793866414c025906ec15033512ed
+
+RUN set -ex \
+ && apt update \
+ && apt install -y \
+        libboost-atomic1.62.0 \
+        libboost-chrono1.62.0 \
+        libboost-graph1.62.0 \
+        libboost-date-time1.62.0 \
+        libboost-program-options1.62.0 \
+        libboost-system1.62.0 \
+        libboost-thread1.62.0 \
+        libcgal12 \
+ && apt install -y \
+        build-essential \
+        cmake \
+        wget \
+        libboost-graph-dev \
+        libcgal-dev \
+        libpq-dev \
+        postgresql-server-dev-${PG_MAJOR} \
+ && wget -O pgrouting.tar.gz "https://github.com/pgRouting/pgrouting/archive/v${PGROUTING_VERSION}.tar.gz" \
+ && echo "$PGROUTING_SHA256 *pgrouting.tar.gz" | sha256sum -c - \
+ && mkdir -p /usr/src/pgrouting \
+ && tar \
+        --extract \
+        --file pgrouting.tar.gz \
+        --directory /usr/src/pgrouting \
+        --strip-components 1 \
+ && rm pgrouting.tar.gz \
+ && cd /usr/src/pgrouting \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd / \
+ && rm -rf /usr/src/pgrouting \
+ && apt-mark manual postgresql-11 \
+ && apt purge -y --autoremove \
+        build-essential \
+        cmake \
+        wget \
+        libcgal-dev \
+        libpq-dev \
+        libboost-graph-dev \
+        postgresql-server-dev-${PG_MAJOR} \
+ && rm -rf /var/lib/apt/lists/*
+RUN rm /docker-entrypoint-initdb.d/10_postgis.sh

--- a/11-3.2-3.3.2/README.md
+++ b/11-3.2-3.3.2/README.md
@@ -1,0 +1,3 @@
+# pgRouting 3.3.2 (pg11)
+
+pgRouting Docker image (version 3.3.2) built over [Postgres 11/PostGIS 3.2](https://hub.docker.com/r/postgis/postgis) and dependencies.

--- a/11-3.2-3.3.2/docker-compose.yml
+++ b/11-3.2-3.3.2/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3"
+services:
+  postgis:
+    image: pgrouting/pgrouting:11-3.2-3.3.2
+    ports:
+      - "5432:5432"
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_PASSWORD=postgres
+volumes:
+  db-data:

--- a/11-3.2-3.3.2/extra/Dockerfile
+++ b/11-3.2-3.3.2/extra/Dockerfile
@@ -1,0 +1,44 @@
+FROM pgrouting/pgrouting:11-3.2-3.3.2
+
+ENV OSM2PGROUTING_VERSION 2.3.8
+
+RUN apt update \
+ && apt install -y \
+        libpqxx-4.0v5 \
+ && apt install -y \
+        build-essential \
+        cmake \
+        wget \
+        libboost-program-options-dev \
+        libexpat1 \
+        libexpat-dev \
+        libosmium2-dev \
+        libpqxx-dev \
+        zlib1g-dev \
+ && cd /usr/local/src \
+ && wget https://github.com/pgRouting/osm2pgrouting/archive/v${OSM2PGROUTING_VERSION}.tar.gz \
+ && tar xvf v${OSM2PGROUTING_VERSION}.tar.gz \
+ && cd osm2pgrouting-${OSM2PGROUTING_VERSION} \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd ../tools/osmium/ \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd /usr/local/src \
+ && rm -rf ./* \
+ && apt purge -y --autoremove \
+        build-essential \
+        cmake \
+        wget \
+        libexpat-dev \
+        libosmium2-dev \
+        libpqxx-dev \
+        zlib1g-dev \
+ && apt autoremove -y \
+ && rm -rf /var/lib/apt/lists/*

--- a/12-3.0-2.6.3/extra/Dockerfile
+++ b/12-3.0-2.6.3/extra/Dockerfile
@@ -1,6 +1,6 @@
 FROM pgrouting/pgrouting:12-3.0-2.6.3
 
-ENV OSM2PGROUTING_VERSION 2.3.7
+ENV OSM2PGROUTING_VERSION 2.3.8
 
 RUN apt update \
  && apt install -y \

--- a/12-3.0-3.0.0/extra/Dockerfile
+++ b/12-3.0-3.0.0/extra/Dockerfile
@@ -1,6 +1,6 @@
 FROM pgrouting/pgrouting:12-3.0-3.0.0
 
-ENV OSM2PGROUTING_VERSION 2.3.7
+ENV OSM2PGROUTING_VERSION 2.3.8
 
 RUN apt update \
  && apt install -y \

--- a/12-3.0-3.0.1/extra/Dockerfile
+++ b/12-3.0-3.0.1/extra/Dockerfile
@@ -1,6 +1,6 @@
 FROM pgrouting/pgrouting:12-3.0-3.0.1
 
-ENV OSM2PGROUTING_VERSION 2.3.7
+ENV OSM2PGROUTING_VERSION 2.3.8
 
 RUN apt update \
  && apt install -y \

--- a/12-3.0-3.1.0/extra/Dockerfile
+++ b/12-3.0-3.1.0/extra/Dockerfile
@@ -1,6 +1,6 @@
 FROM pgrouting/pgrouting:12-3.0-3.1.0
 
-ENV OSM2PGROUTING_VERSION 2.3.7
+ENV OSM2PGROUTING_VERSION 2.3.8
 
 RUN apt update \
  && apt install -y \

--- a/12-3.0-3.1.1/extra/Dockerfile
+++ b/12-3.0-3.1.1/extra/Dockerfile
@@ -1,6 +1,6 @@
 FROM pgrouting/pgrouting:12-3.0-3.1.1
 
-ENV OSM2PGROUTING_VERSION 2.3.7
+ENV OSM2PGROUTING_VERSION 2.3.8
 
 RUN apt update \
  && apt install -y \

--- a/12-3.0-develop/Dockerfile
+++ b/12-3.0-develop/Dockerfile
@@ -3,7 +3,7 @@ FROM postgis/postgis:12-3.0
 LABEL maintainer="pgRouting Project - https://pgrouting.net"
 
 ENV PGROUTING_VERSION develop
-ENV PGROUTING_GIT_HASH fb48e16f2d3c0f11060d58fc8be36e9325db2f59
+ENV PGROUTING_GIT_HASH 7fcfc858d63fdc6060f9ba22138fbfb247672558
 
 RUN apt update \
  && apt install -y \

--- a/12-3.0-develop/extra/Dockerfile
+++ b/12-3.0-develop/extra/Dockerfile
@@ -1,6 +1,6 @@
 FROM pgrouting/pgrouting:12-3.0-develop
 
-ENV OSM2PGROUTING_VERSION 2.3.7
+ENV OSM2PGROUTING_VERSION 2.3.8
 
 RUN apt update \
  && apt install -y \

--- a/12-3.0-main/Dockerfile
+++ b/12-3.0-main/Dockerfile
@@ -3,7 +3,7 @@ FROM postgis/postgis:12-3.0
 LABEL maintainer="pgRouting Project - https://pgrouting.net"
 
 ENV PGROUTING_VERSION main
-ENV PGROUTING_GIT_HASH
+ENV PGROUTING_GIT_HASH 1d4f0a5c7ae815ff1ed31ae90171825a764dbf72
 
 RUN apt update \
  && apt install -y \

--- a/12-3.0-main/Dockerfile
+++ b/12-3.0-main/Dockerfile
@@ -1,20 +1,20 @@
-FROM postgis/postgis:10-2.5
+FROM postgis/postgis:12-3.0
 
 LABEL maintainer="pgRouting Project - https://pgrouting.net"
 
-ENV PGROUTING_VERSION master
-ENV PGROUTING_GIT_HASH 
+ENV PGROUTING_VERSION main
+ENV PGROUTING_GIT_HASH
 
 RUN apt update \
  && apt install -y \
-        libboost-atomic1.62.0 \
-        libboost-chrono1.62.0 \
-        libboost-graph1.62.0 \
-        libboost-date-time1.62.0 \
-        libboost-program-options1.62.0 \
-        libboost-system1.62.0 \
-        libboost-thread1.62.0 \
-        libcgal12 \
+        libboost-atomic1.67.0 \
+        libboost-chrono1.67.0 \
+        libboost-graph1.67.0 \
+        libboost-date-time1.67.0 \
+        libboost-program-options1.67.0 \
+        libboost-system1.67.0 \
+        libboost-thread1.67.0 \
+        libcgal13 \
  && apt install -y \
         build-essential \
         cmake \

--- a/12-3.0-main/README.md
+++ b/12-3.0-main/README.md
@@ -1,0 +1,3 @@
+# pgRouting main (pg12)
+
+pgRouting Docker image (version main) built over [Postgres 12/PostGIS 3.0](https://hub.docker.com/r/postgis/postgis) and dependencies.

--- a/12-3.0-main/docker-compose.yml
+++ b/12-3.0-main/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   postgis:
-    image: pgrouting/pgrouting:12-3.0-master
+    image: pgrouting/pgrouting:12-3.0-main
     ports:
       - "5432:5432"
     volumes:

--- a/12-3.0-main/extra/Dockerfile
+++ b/12-3.0-main/extra/Dockerfile
@@ -1,4 +1,4 @@
-FROM pgrouting/pgrouting:12-3.0-master
+FROM pgrouting/pgrouting:12-3.0-main
 
 ENV OSM2PGROUTING_VERSION 2.3.8
 

--- a/12-3.0-master/README.md
+++ b/12-3.0-master/README.md
@@ -1,3 +1,0 @@
-# pgRouting master (pg12)
-
-pgRouting Docker image (version master) built over [Postgres 12/PostGIS 3.0](https://hub.docker.com/r/postgis/postgis) and dependencies.

--- a/12-3.0-master/extra/Dockerfile
+++ b/12-3.0-master/extra/Dockerfile
@@ -1,6 +1,6 @@
 FROM pgrouting/pgrouting:12-3.0-master
 
-ENV OSM2PGROUTING_VERSION 2.3.7
+ENV OSM2PGROUTING_VERSION 2.3.8
 
 RUN apt update \
  && apt install -y \

--- a/12-3.1-3.1.3/extra/Dockerfile
+++ b/12-3.1-3.1.3/extra/Dockerfile
@@ -1,6 +1,6 @@
 FROM pgrouting/pgrouting:12-3.1-3.1.3
 
-ENV OSM2PGROUTING_VERSION 2.3.7
+ENV OSM2PGROUTING_VERSION 2.3.8
 
 RUN apt update \
  && apt install -y \

--- a/12-3.1-3.2.0/extra/Dockerfile
+++ b/12-3.1-3.2.0/extra/Dockerfile
@@ -1,6 +1,6 @@
 FROM pgrouting/pgrouting:12-3.1-3.2.0
 
-ENV OSM2PGROUTING_VERSION 2.3.7
+ENV OSM2PGROUTING_VERSION 2.3.8
 
 RUN apt update \
  && apt install -y \

--- a/12-3.1-3.2.1/extra/Dockerfile
+++ b/12-3.1-3.2.1/extra/Dockerfile
@@ -1,6 +1,6 @@
 FROM pgrouting/pgrouting:12-3.1-3.2.1
 
-ENV OSM2PGROUTING_VERSION 2.3.7
+ENV OSM2PGROUTING_VERSION 2.3.8
 
 RUN apt update \
  && apt install -y \

--- a/12-3.2-3.0.6/Dockerfile
+++ b/12-3.2-3.0.6/Dockerfile
@@ -1,0 +1,54 @@
+FROM postgis/postgis:12-3.2
+
+LABEL maintainer="pgRouting Project - https://pgrouting.net"
+
+ENV PGROUTING_VERSION 3.0.6
+ENV PGROUTING_SHA256 9852e1e8f2da9137fb6120acee05dfb8edcff00bf06ff40a61291d91e84c69e9
+
+RUN set -ex \
+ && apt update \
+ && apt install -y \
+        libboost-atomic1.67.0 \
+        libboost-chrono1.67.0 \
+        libboost-graph1.67.0 \
+        libboost-date-time1.67.0 \
+        libboost-program-options1.67.0 \
+        libboost-system1.67.0 \
+        libboost-thread1.67.0 \
+        libcgal13 \
+ && apt install -y \
+        build-essential \
+        cmake \
+        wget \
+        libboost-graph-dev \
+        libcgal-dev \
+        libpq-dev \
+        postgresql-server-dev-${PG_MAJOR} \
+ && wget -O pgrouting.tar.gz "https://github.com/pgRouting/pgrouting/archive/v${PGROUTING_VERSION}.tar.gz" \
+ && echo "$PGROUTING_SHA256 *pgrouting.tar.gz" | sha256sum -c - \
+ && mkdir -p /usr/src/pgrouting \
+ && tar \
+        --extract \
+        --file pgrouting.tar.gz \
+        --directory /usr/src/pgrouting \
+        --strip-components 1 \
+ && rm pgrouting.tar.gz \
+ && cd /usr/src/pgrouting \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd / \
+ && rm -rf /usr/src/pgrouting \
+ && apt-mark manual postgresql-12 \
+ && apt purge -y --autoremove \
+        build-essential \
+        cmake \
+        wget \
+        libcgal-dev \
+        libpq-dev \
+        libboost-graph-dev \
+        postgresql-server-dev-${PG_MAJOR} \
+ && rm -rf /var/lib/apt/lists/*
+RUN rm /docker-entrypoint-initdb.d/10_postgis.sh

--- a/12-3.2-3.0.6/README.md
+++ b/12-3.2-3.0.6/README.md
@@ -1,0 +1,3 @@
+# pgRouting 3.0.6 (pg12)
+
+pgRouting Docker image (version 3.0.6) built over [Postgres 12/PostGIS 3.2](https://hub.docker.com/r/postgis/postgis) and dependencies.

--- a/12-3.2-3.0.6/docker-compose.yml
+++ b/12-3.2-3.0.6/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3"
+services:
+  postgis:
+    image: pgrouting/pgrouting:12-3.2-3.0.6
+    ports:
+      - "5432:5432"
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_PASSWORD=postgres
+volumes:
+  db-data:

--- a/12-3.2-3.0.6/extra/Dockerfile
+++ b/12-3.2-3.0.6/extra/Dockerfile
@@ -1,0 +1,44 @@
+FROM pgrouting/pgrouting:12-3.2-3.0.6
+
+ENV OSM2PGROUTING_VERSION 2.3.8
+
+RUN apt update \
+ && apt install -y \
+        libpqxx-6.2 \
+ && apt install -y \
+        build-essential \
+        cmake \
+        wget \
+        libboost-program-options-dev \
+        libexpat1 \
+        libexpat-dev \
+        libosmium2-dev \
+        libpqxx-dev \
+        zlib1g-dev \
+ && cd /usr/local/src \
+ && wget https://github.com/pgRouting/osm2pgrouting/archive/v${OSM2PGROUTING_VERSION}.tar.gz \
+ && tar xvf v${OSM2PGROUTING_VERSION}.tar.gz \
+ && cd osm2pgrouting-${OSM2PGROUTING_VERSION} \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd ../tools/osmium/ \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd /usr/local/src \
+ && rm -rf ./* \
+ && apt purge -y --autoremove \
+        build-essential \
+        cmake \
+        wget \
+        libexpat-dev \
+        libosmium2-dev \
+        libpqxx-dev \
+        zlib1g-dev \
+ && apt autoremove -y \
+ && rm -rf /var/lib/apt/lists/*

--- a/12-3.2-3.1.4/Dockerfile
+++ b/12-3.2-3.1.4/Dockerfile
@@ -1,0 +1,54 @@
+FROM postgis/postgis:12-3.2
+
+LABEL maintainer="pgRouting Project - https://pgrouting.net"
+
+ENV PGROUTING_VERSION 3.1.4
+ENV PGROUTING_SHA256 dcd05817b187e5c3f0cb741148db230a5f8d114b9738b6395057a9473b816842
+
+RUN set -ex \
+ && apt update \
+ && apt install -y \
+        libboost-atomic1.67.0 \
+        libboost-chrono1.67.0 \
+        libboost-graph1.67.0 \
+        libboost-date-time1.67.0 \
+        libboost-program-options1.67.0 \
+        libboost-system1.67.0 \
+        libboost-thread1.67.0 \
+        libcgal13 \
+ && apt install -y \
+        build-essential \
+        cmake \
+        wget \
+        libboost-graph-dev \
+        libcgal-dev \
+        libpq-dev \
+        postgresql-server-dev-${PG_MAJOR} \
+ && wget -O pgrouting.tar.gz "https://github.com/pgRouting/pgrouting/archive/v${PGROUTING_VERSION}.tar.gz" \
+ && echo "$PGROUTING_SHA256 *pgrouting.tar.gz" | sha256sum -c - \
+ && mkdir -p /usr/src/pgrouting \
+ && tar \
+        --extract \
+        --file pgrouting.tar.gz \
+        --directory /usr/src/pgrouting \
+        --strip-components 1 \
+ && rm pgrouting.tar.gz \
+ && cd /usr/src/pgrouting \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd / \
+ && rm -rf /usr/src/pgrouting \
+ && apt-mark manual postgresql-12 \
+ && apt purge -y --autoremove \
+        build-essential \
+        cmake \
+        wget \
+        libcgal-dev \
+        libpq-dev \
+        libboost-graph-dev \
+        postgresql-server-dev-${PG_MAJOR} \
+ && rm -rf /var/lib/apt/lists/*
+RUN rm /docker-entrypoint-initdb.d/10_postgis.sh

--- a/12-3.2-3.1.4/README.md
+++ b/12-3.2-3.1.4/README.md
@@ -1,0 +1,3 @@
+# pgRouting 3.1.4 (pg12)
+
+pgRouting Docker image (version 3.1.4) built over [Postgres 12/PostGIS 3.2](https://hub.docker.com/r/postgis/postgis) and dependencies.

--- a/12-3.2-3.1.4/docker-compose.yml
+++ b/12-3.2-3.1.4/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3"
+services:
+  postgis:
+    image: pgrouting/pgrouting:12-3.2-3.1.4
+    ports:
+      - "5432:5432"
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_PASSWORD=postgres
+volumes:
+  db-data:

--- a/12-3.2-3.1.4/extra/Dockerfile
+++ b/12-3.2-3.1.4/extra/Dockerfile
@@ -1,0 +1,44 @@
+FROM pgrouting/pgrouting:12-3.2-3.1.4
+
+ENV OSM2PGROUTING_VERSION 2.3.8
+
+RUN apt update \
+ && apt install -y \
+        libpqxx-6.2 \
+ && apt install -y \
+        build-essential \
+        cmake \
+        wget \
+        libboost-program-options-dev \
+        libexpat1 \
+        libexpat-dev \
+        libosmium2-dev \
+        libpqxx-dev \
+        zlib1g-dev \
+ && cd /usr/local/src \
+ && wget https://github.com/pgRouting/osm2pgrouting/archive/v${OSM2PGROUTING_VERSION}.tar.gz \
+ && tar xvf v${OSM2PGROUTING_VERSION}.tar.gz \
+ && cd osm2pgrouting-${OSM2PGROUTING_VERSION} \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd ../tools/osmium/ \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd /usr/local/src \
+ && rm -rf ./* \
+ && apt purge -y --autoremove \
+        build-essential \
+        cmake \
+        wget \
+        libexpat-dev \
+        libosmium2-dev \
+        libpqxx-dev \
+        zlib1g-dev \
+ && apt autoremove -y \
+ && rm -rf /var/lib/apt/lists/*

--- a/12-3.2-3.2.2/Dockerfile
+++ b/12-3.2-3.2.2/Dockerfile
@@ -1,0 +1,54 @@
+FROM postgis/postgis:12-3.2
+
+LABEL maintainer="pgRouting Project - https://pgrouting.net"
+
+ENV PGROUTING_VERSION 3.2.2
+ENV PGROUTING_SHA256 40f67ab944b5a7d91d4eb610cba3ed34a83daf51bb569c75b582f8e88efb72de
+
+RUN set -ex \
+ && apt update \
+ && apt install -y \
+        libboost-atomic1.67.0 \
+        libboost-chrono1.67.0 \
+        libboost-graph1.67.0 \
+        libboost-date-time1.67.0 \
+        libboost-program-options1.67.0 \
+        libboost-system1.67.0 \
+        libboost-thread1.67.0 \
+        libcgal13 \
+ && apt install -y \
+        build-essential \
+        cmake \
+        wget \
+        libboost-graph-dev \
+        libcgal-dev \
+        libpq-dev \
+        postgresql-server-dev-${PG_MAJOR} \
+ && wget -O pgrouting.tar.gz "https://github.com/pgRouting/pgrouting/archive/v${PGROUTING_VERSION}.tar.gz" \
+ && echo "$PGROUTING_SHA256 *pgrouting.tar.gz" | sha256sum -c - \
+ && mkdir -p /usr/src/pgrouting \
+ && tar \
+        --extract \
+        --file pgrouting.tar.gz \
+        --directory /usr/src/pgrouting \
+        --strip-components 1 \
+ && rm pgrouting.tar.gz \
+ && cd /usr/src/pgrouting \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd / \
+ && rm -rf /usr/src/pgrouting \
+ && apt-mark manual postgresql-12 \
+ && apt purge -y --autoremove \
+        build-essential \
+        cmake \
+        wget \
+        libcgal-dev \
+        libpq-dev \
+        libboost-graph-dev \
+        postgresql-server-dev-${PG_MAJOR} \
+ && rm -rf /var/lib/apt/lists/*
+RUN rm /docker-entrypoint-initdb.d/10_postgis.sh

--- a/12-3.2-3.2.2/README.md
+++ b/12-3.2-3.2.2/README.md
@@ -1,0 +1,3 @@
+# pgRouting 3.2.2 (pg12)
+
+pgRouting Docker image (version 3.2.2) built over [Postgres 12/PostGIS 3.2](https://hub.docker.com/r/postgis/postgis) and dependencies.

--- a/12-3.2-3.2.2/docker-compose.yml
+++ b/12-3.2-3.2.2/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3"
+services:
+  postgis:
+    image: pgrouting/pgrouting:12-3.2-3.2.2
+    ports:
+      - "5432:5432"
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_PASSWORD=postgres
+volumes:
+  db-data:

--- a/12-3.2-3.2.2/extra/Dockerfile
+++ b/12-3.2-3.2.2/extra/Dockerfile
@@ -1,0 +1,44 @@
+FROM pgrouting/pgrouting:12-3.2-3.2.2
+
+ENV OSM2PGROUTING_VERSION 2.3.8
+
+RUN apt update \
+ && apt install -y \
+        libpqxx-6.2 \
+ && apt install -y \
+        build-essential \
+        cmake \
+        wget \
+        libboost-program-options-dev \
+        libexpat1 \
+        libexpat-dev \
+        libosmium2-dev \
+        libpqxx-dev \
+        zlib1g-dev \
+ && cd /usr/local/src \
+ && wget https://github.com/pgRouting/osm2pgrouting/archive/v${OSM2PGROUTING_VERSION}.tar.gz \
+ && tar xvf v${OSM2PGROUTING_VERSION}.tar.gz \
+ && cd osm2pgrouting-${OSM2PGROUTING_VERSION} \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd ../tools/osmium/ \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd /usr/local/src \
+ && rm -rf ./* \
+ && apt purge -y --autoremove \
+        build-essential \
+        cmake \
+        wget \
+        libexpat-dev \
+        libosmium2-dev \
+        libpqxx-dev \
+        zlib1g-dev \
+ && apt autoremove -y \
+ && rm -rf /var/lib/apt/lists/*

--- a/12-3.2-3.3.2/Dockerfile
+++ b/12-3.2-3.3.2/Dockerfile
@@ -1,0 +1,54 @@
+FROM postgis/postgis:12-3.2
+
+LABEL maintainer="pgRouting Project - https://pgrouting.net"
+
+ENV PGROUTING_VERSION 3.3.2
+ENV PGROUTING_SHA256 d5558cd419c8d46bdc958064cb97f963d1ea793866414c025906ec15033512ed
+
+RUN set -ex \
+ && apt update \
+ && apt install -y \
+        libboost-atomic1.67.0 \
+        libboost-chrono1.67.0 \
+        libboost-graph1.67.0 \
+        libboost-date-time1.67.0 \
+        libboost-program-options1.67.0 \
+        libboost-system1.67.0 \
+        libboost-thread1.67.0 \
+        libcgal13 \
+ && apt install -y \
+        build-essential \
+        cmake \
+        wget \
+        libboost-graph-dev \
+        libcgal-dev \
+        libpq-dev \
+        postgresql-server-dev-${PG_MAJOR} \
+ && wget -O pgrouting.tar.gz "https://github.com/pgRouting/pgrouting/archive/v${PGROUTING_VERSION}.tar.gz" \
+ && echo "$PGROUTING_SHA256 *pgrouting.tar.gz" | sha256sum -c - \
+ && mkdir -p /usr/src/pgrouting \
+ && tar \
+        --extract \
+        --file pgrouting.tar.gz \
+        --directory /usr/src/pgrouting \
+        --strip-components 1 \
+ && rm pgrouting.tar.gz \
+ && cd /usr/src/pgrouting \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd / \
+ && rm -rf /usr/src/pgrouting \
+ && apt-mark manual postgresql-12 \
+ && apt purge -y --autoremove \
+        build-essential \
+        cmake \
+        wget \
+        libcgal-dev \
+        libpq-dev \
+        libboost-graph-dev \
+        postgresql-server-dev-${PG_MAJOR} \
+ && rm -rf /var/lib/apt/lists/*
+RUN rm /docker-entrypoint-initdb.d/10_postgis.sh

--- a/12-3.2-3.3.2/README.md
+++ b/12-3.2-3.3.2/README.md
@@ -1,0 +1,3 @@
+# pgRouting 3.3.2 (pg12)
+
+pgRouting Docker image (version 3.3.2) built over [Postgres 12/PostGIS 3.2](https://hub.docker.com/r/postgis/postgis) and dependencies.

--- a/12-3.2-3.3.2/docker-compose.yml
+++ b/12-3.2-3.3.2/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3"
+services:
+  postgis:
+    image: pgrouting/pgrouting:12-3.2-3.3.2
+    ports:
+      - "5432:5432"
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_PASSWORD=postgres
+volumes:
+  db-data:

--- a/12-3.2-3.3.2/extra/Dockerfile
+++ b/12-3.2-3.3.2/extra/Dockerfile
@@ -1,0 +1,44 @@
+FROM pgrouting/pgrouting:12-3.2-3.3.2
+
+ENV OSM2PGROUTING_VERSION 2.3.8
+
+RUN apt update \
+ && apt install -y \
+        libpqxx-6.2 \
+ && apt install -y \
+        build-essential \
+        cmake \
+        wget \
+        libboost-program-options-dev \
+        libexpat1 \
+        libexpat-dev \
+        libosmium2-dev \
+        libpqxx-dev \
+        zlib1g-dev \
+ && cd /usr/local/src \
+ && wget https://github.com/pgRouting/osm2pgrouting/archive/v${OSM2PGROUTING_VERSION}.tar.gz \
+ && tar xvf v${OSM2PGROUTING_VERSION}.tar.gz \
+ && cd osm2pgrouting-${OSM2PGROUTING_VERSION} \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd ../tools/osmium/ \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd /usr/local/src \
+ && rm -rf ./* \
+ && apt purge -y --autoremove \
+        build-essential \
+        cmake \
+        wget \
+        libexpat-dev \
+        libosmium2-dev \
+        libpqxx-dev \
+        zlib1g-dev \
+ && apt autoremove -y \
+ && rm -rf /var/lib/apt/lists/*

--- a/13-3.0-3.1.0/extra/Dockerfile
+++ b/13-3.0-3.1.0/extra/Dockerfile
@@ -1,6 +1,6 @@
 FROM pgrouting/pgrouting:13-3.0-3.1.0
 
-ENV OSM2PGROUTING_VERSION 2.3.7
+ENV OSM2PGROUTING_VERSION 2.3.8
 
 RUN apt update \
  && apt install -y \

--- a/13-3.0-3.1.1/extra/Dockerfile
+++ b/13-3.0-3.1.1/extra/Dockerfile
@@ -1,6 +1,6 @@
 FROM pgrouting/pgrouting:13-3.0-3.1.1
 
-ENV OSM2PGROUTING_VERSION 2.3.7
+ENV OSM2PGROUTING_VERSION 2.3.8
 
 RUN apt update \
  && apt install -y \

--- a/13-3.0-develop/Dockerfile
+++ b/13-3.0-develop/Dockerfile
@@ -3,7 +3,7 @@ FROM postgis/postgis:13-3.0
 LABEL maintainer="pgRouting Project - https://pgrouting.net"
 
 ENV PGROUTING_VERSION develop
-ENV PGROUTING_GIT_HASH fb48e16f2d3c0f11060d58fc8be36e9325db2f59
+ENV PGROUTING_GIT_HASH 7fcfc858d63fdc6060f9ba22138fbfb247672558
 
 RUN apt update \
  && apt install -y \

--- a/13-3.0-develop/extra/Dockerfile
+++ b/13-3.0-develop/extra/Dockerfile
@@ -1,6 +1,6 @@
 FROM pgrouting/pgrouting:13-3.0-develop
 
-ENV OSM2PGROUTING_VERSION 2.3.7
+ENV OSM2PGROUTING_VERSION 2.3.8
 
 RUN apt update \
  && apt install -y \

--- a/13-3.0-main/Dockerfile
+++ b/13-3.0-main/Dockerfile
@@ -3,7 +3,7 @@ FROM postgis/postgis:13-3.0
 LABEL maintainer="pgRouting Project - https://pgrouting.net"
 
 ENV PGROUTING_VERSION main
-ENV PGROUTING_GIT_HASH
+ENV PGROUTING_GIT_HASH 1d4f0a5c7ae815ff1ed31ae90171825a764dbf72
 
 RUN apt update \
  && apt install -y \

--- a/13-3.0-main/Dockerfile
+++ b/13-3.0-main/Dockerfile
@@ -1,9 +1,9 @@
-FROM postgis/postgis:12-3.0
+FROM postgis/postgis:13-3.0
 
 LABEL maintainer="pgRouting Project - https://pgrouting.net"
 
-ENV PGROUTING_VERSION master
-ENV PGROUTING_GIT_HASH 
+ENV PGROUTING_VERSION main
+ENV PGROUTING_GIT_HASH
 
 RUN apt update \
  && apt install -y \

--- a/13-3.0-main/README.md
+++ b/13-3.0-main/README.md
@@ -1,0 +1,3 @@
+# pgRouting main (pg13)
+
+pgRouting Docker image (version main) built over [Postgres 13/PostGIS 3.0](https://hub.docker.com/r/postgis/postgis) and dependencies.

--- a/13-3.0-main/docker-compose.yml
+++ b/13-3.0-main/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   postgis:
-    image: pgrouting/pgrouting:10-2.5-master
+    image: pgrouting/pgrouting:13-3.0-main
     ports:
       - "5432:5432"
     volumes:

--- a/13-3.0-main/extra/Dockerfile
+++ b/13-3.0-main/extra/Dockerfile
@@ -1,10 +1,10 @@
-FROM pgrouting/pgrouting:11-2.5-master
+FROM pgrouting/pgrouting:13-3.0-main
 
 ENV OSM2PGROUTING_VERSION 2.3.8
 
 RUN apt update \
  && apt install -y \
-        libpqxx-4.0v5 \
+        libpqxx-6.2 \
  && apt install -y \
         build-essential \
         cmake \

--- a/13-3.0-master/README.md
+++ b/13-3.0-master/README.md
@@ -1,3 +1,0 @@
-# pgRouting master (pg13)
-
-pgRouting Docker image (version master) built over [Postgres 13/PostGIS 3.0](https://hub.docker.com/r/postgis/postgis) and dependencies.

--- a/13-3.0-master/extra/Dockerfile
+++ b/13-3.0-master/extra/Dockerfile
@@ -1,6 +1,6 @@
 FROM pgrouting/pgrouting:13-3.0-master
 
-ENV OSM2PGROUTING_VERSION 2.3.7
+ENV OSM2PGROUTING_VERSION 2.3.8
 
 RUN apt update \
  && apt install -y \

--- a/13-3.1-3.1.3/extra/Dockerfile
+++ b/13-3.1-3.1.3/extra/Dockerfile
@@ -1,6 +1,6 @@
 FROM pgrouting/pgrouting:13-3.1-3.1.3
 
-ENV OSM2PGROUTING_VERSION 2.3.7
+ENV OSM2PGROUTING_VERSION 2.3.8
 
 RUN apt update \
  && apt install -y \

--- a/13-3.1-3.2.0/extra/Dockerfile
+++ b/13-3.1-3.2.0/extra/Dockerfile
@@ -1,6 +1,6 @@
 FROM pgrouting/pgrouting:13-3.1-3.2.0
 
-ENV OSM2PGROUTING_VERSION 2.3.7
+ENV OSM2PGROUTING_VERSION 2.3.8
 
 RUN apt update \
  && apt install -y \

--- a/13-3.1-3.2.1/extra/Dockerfile
+++ b/13-3.1-3.2.1/extra/Dockerfile
@@ -1,6 +1,6 @@
 FROM pgrouting/pgrouting:13-3.1-3.2.1
 
-ENV OSM2PGROUTING_VERSION 2.3.7
+ENV OSM2PGROUTING_VERSION 2.3.8
 
 RUN apt update \
  && apt install -y \

--- a/13-3.2-3.0.6/Dockerfile
+++ b/13-3.2-3.0.6/Dockerfile
@@ -1,0 +1,54 @@
+FROM postgis/postgis:13-3.2
+
+LABEL maintainer="pgRouting Project - https://pgrouting.net"
+
+ENV PGROUTING_VERSION 3.0.6
+ENV PGROUTING_SHA256 9852e1e8f2da9137fb6120acee05dfb8edcff00bf06ff40a61291d91e84c69e9
+
+RUN set -ex \
+ && apt update \
+ && apt install -y \
+        libboost-atomic1.67.0 \
+        libboost-chrono1.67.0 \
+        libboost-graph1.67.0 \
+        libboost-date-time1.67.0 \
+        libboost-program-options1.67.0 \
+        libboost-system1.67.0 \
+        libboost-thread1.67.0 \
+        libcgal13 \
+ && apt install -y \
+        build-essential \
+        cmake \
+        wget \
+        libboost-graph-dev \
+        libcgal-dev \
+        libpq-dev \
+        postgresql-server-dev-${PG_MAJOR} \
+ && wget -O pgrouting.tar.gz "https://github.com/pgRouting/pgrouting/archive/v${PGROUTING_VERSION}.tar.gz" \
+ && echo "$PGROUTING_SHA256 *pgrouting.tar.gz" | sha256sum -c - \
+ && mkdir -p /usr/src/pgrouting \
+ && tar \
+        --extract \
+        --file pgrouting.tar.gz \
+        --directory /usr/src/pgrouting \
+        --strip-components 1 \
+ && rm pgrouting.tar.gz \
+ && cd /usr/src/pgrouting \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd / \
+ && rm -rf /usr/src/pgrouting \
+ && apt-mark manual postgresql-13 \
+ && apt purge -y --autoremove \
+        build-essential \
+        cmake \
+        wget \
+        libcgal-dev \
+        libpq-dev \
+        libboost-graph-dev \
+        postgresql-server-dev-${PG_MAJOR} \
+ && rm -rf /var/lib/apt/lists/*
+RUN rm /docker-entrypoint-initdb.d/10_postgis.sh

--- a/13-3.2-3.0.6/README.md
+++ b/13-3.2-3.0.6/README.md
@@ -1,0 +1,3 @@
+# pgRouting 3.0.6 (pg13)
+
+pgRouting Docker image (version 3.0.6) built over [Postgres 13/PostGIS 3.2](https://hub.docker.com/r/postgis/postgis) and dependencies.

--- a/13-3.2-3.0.6/docker-compose.yml
+++ b/13-3.2-3.0.6/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3"
+services:
+  postgis:
+    image: pgrouting/pgrouting:13-3.2-3.0.6
+    ports:
+      - "5432:5432"
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_PASSWORD=postgres
+volumes:
+  db-data:

--- a/13-3.2-3.0.6/extra/Dockerfile
+++ b/13-3.2-3.0.6/extra/Dockerfile
@@ -1,0 +1,44 @@
+FROM pgrouting/pgrouting:13-3.2-3.0.6
+
+ENV OSM2PGROUTING_VERSION 2.3.8
+
+RUN apt update \
+ && apt install -y \
+        libpqxx-6.2 \
+ && apt install -y \
+        build-essential \
+        cmake \
+        wget \
+        libboost-program-options-dev \
+        libexpat1 \
+        libexpat-dev \
+        libosmium2-dev \
+        libpqxx-dev \
+        zlib1g-dev \
+ && cd /usr/local/src \
+ && wget https://github.com/pgRouting/osm2pgrouting/archive/v${OSM2PGROUTING_VERSION}.tar.gz \
+ && tar xvf v${OSM2PGROUTING_VERSION}.tar.gz \
+ && cd osm2pgrouting-${OSM2PGROUTING_VERSION} \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd ../tools/osmium/ \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd /usr/local/src \
+ && rm -rf ./* \
+ && apt purge -y --autoremove \
+        build-essential \
+        cmake \
+        wget \
+        libexpat-dev \
+        libosmium2-dev \
+        libpqxx-dev \
+        zlib1g-dev \
+ && apt autoremove -y \
+ && rm -rf /var/lib/apt/lists/*

--- a/13-3.2-3.1.4/Dockerfile
+++ b/13-3.2-3.1.4/Dockerfile
@@ -1,0 +1,54 @@
+FROM postgis/postgis:13-3.2
+
+LABEL maintainer="pgRouting Project - https://pgrouting.net"
+
+ENV PGROUTING_VERSION 3.1.4
+ENV PGROUTING_SHA256 dcd05817b187e5c3f0cb741148db230a5f8d114b9738b6395057a9473b816842
+
+RUN set -ex \
+ && apt update \
+ && apt install -y \
+        libboost-atomic1.67.0 \
+        libboost-chrono1.67.0 \
+        libboost-graph1.67.0 \
+        libboost-date-time1.67.0 \
+        libboost-program-options1.67.0 \
+        libboost-system1.67.0 \
+        libboost-thread1.67.0 \
+        libcgal13 \
+ && apt install -y \
+        build-essential \
+        cmake \
+        wget \
+        libboost-graph-dev \
+        libcgal-dev \
+        libpq-dev \
+        postgresql-server-dev-${PG_MAJOR} \
+ && wget -O pgrouting.tar.gz "https://github.com/pgRouting/pgrouting/archive/v${PGROUTING_VERSION}.tar.gz" \
+ && echo "$PGROUTING_SHA256 *pgrouting.tar.gz" | sha256sum -c - \
+ && mkdir -p /usr/src/pgrouting \
+ && tar \
+        --extract \
+        --file pgrouting.tar.gz \
+        --directory /usr/src/pgrouting \
+        --strip-components 1 \
+ && rm pgrouting.tar.gz \
+ && cd /usr/src/pgrouting \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd / \
+ && rm -rf /usr/src/pgrouting \
+ && apt-mark manual postgresql-13 \
+ && apt purge -y --autoremove \
+        build-essential \
+        cmake \
+        wget \
+        libcgal-dev \
+        libpq-dev \
+        libboost-graph-dev \
+        postgresql-server-dev-${PG_MAJOR} \
+ && rm -rf /var/lib/apt/lists/*
+RUN rm /docker-entrypoint-initdb.d/10_postgis.sh

--- a/13-3.2-3.1.4/README.md
+++ b/13-3.2-3.1.4/README.md
@@ -1,0 +1,3 @@
+# pgRouting 3.1.4 (pg13)
+
+pgRouting Docker image (version 3.1.4) built over [Postgres 13/PostGIS 3.2](https://hub.docker.com/r/postgis/postgis) and dependencies.

--- a/13-3.2-3.1.4/docker-compose.yml
+++ b/13-3.2-3.1.4/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3"
+services:
+  postgis:
+    image: pgrouting/pgrouting:13-3.2-3.1.4
+    ports:
+      - "5432:5432"
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_PASSWORD=postgres
+volumes:
+  db-data:

--- a/13-3.2-3.1.4/extra/Dockerfile
+++ b/13-3.2-3.1.4/extra/Dockerfile
@@ -1,0 +1,44 @@
+FROM pgrouting/pgrouting:13-3.2-3.1.4
+
+ENV OSM2PGROUTING_VERSION 2.3.8
+
+RUN apt update \
+ && apt install -y \
+        libpqxx-6.2 \
+ && apt install -y \
+        build-essential \
+        cmake \
+        wget \
+        libboost-program-options-dev \
+        libexpat1 \
+        libexpat-dev \
+        libosmium2-dev \
+        libpqxx-dev \
+        zlib1g-dev \
+ && cd /usr/local/src \
+ && wget https://github.com/pgRouting/osm2pgrouting/archive/v${OSM2PGROUTING_VERSION}.tar.gz \
+ && tar xvf v${OSM2PGROUTING_VERSION}.tar.gz \
+ && cd osm2pgrouting-${OSM2PGROUTING_VERSION} \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd ../tools/osmium/ \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd /usr/local/src \
+ && rm -rf ./* \
+ && apt purge -y --autoremove \
+        build-essential \
+        cmake \
+        wget \
+        libexpat-dev \
+        libosmium2-dev \
+        libpqxx-dev \
+        zlib1g-dev \
+ && apt autoremove -y \
+ && rm -rf /var/lib/apt/lists/*

--- a/13-3.2-3.2.2/Dockerfile
+++ b/13-3.2-3.2.2/Dockerfile
@@ -1,0 +1,54 @@
+FROM postgis/postgis:13-3.2
+
+LABEL maintainer="pgRouting Project - https://pgrouting.net"
+
+ENV PGROUTING_VERSION 3.2.2
+ENV PGROUTING_SHA256 40f67ab944b5a7d91d4eb610cba3ed34a83daf51bb569c75b582f8e88efb72de
+
+RUN set -ex \
+ && apt update \
+ && apt install -y \
+        libboost-atomic1.67.0 \
+        libboost-chrono1.67.0 \
+        libboost-graph1.67.0 \
+        libboost-date-time1.67.0 \
+        libboost-program-options1.67.0 \
+        libboost-system1.67.0 \
+        libboost-thread1.67.0 \
+        libcgal13 \
+ && apt install -y \
+        build-essential \
+        cmake \
+        wget \
+        libboost-graph-dev \
+        libcgal-dev \
+        libpq-dev \
+        postgresql-server-dev-${PG_MAJOR} \
+ && wget -O pgrouting.tar.gz "https://github.com/pgRouting/pgrouting/archive/v${PGROUTING_VERSION}.tar.gz" \
+ && echo "$PGROUTING_SHA256 *pgrouting.tar.gz" | sha256sum -c - \
+ && mkdir -p /usr/src/pgrouting \
+ && tar \
+        --extract \
+        --file pgrouting.tar.gz \
+        --directory /usr/src/pgrouting \
+        --strip-components 1 \
+ && rm pgrouting.tar.gz \
+ && cd /usr/src/pgrouting \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd / \
+ && rm -rf /usr/src/pgrouting \
+ && apt-mark manual postgresql-13 \
+ && apt purge -y --autoremove \
+        build-essential \
+        cmake \
+        wget \
+        libcgal-dev \
+        libpq-dev \
+        libboost-graph-dev \
+        postgresql-server-dev-${PG_MAJOR} \
+ && rm -rf /var/lib/apt/lists/*
+RUN rm /docker-entrypoint-initdb.d/10_postgis.sh

--- a/13-3.2-3.2.2/README.md
+++ b/13-3.2-3.2.2/README.md
@@ -1,0 +1,3 @@
+# pgRouting 3.2.2 (pg13)
+
+pgRouting Docker image (version 3.2.2) built over [Postgres 13/PostGIS 3.2](https://hub.docker.com/r/postgis/postgis) and dependencies.

--- a/13-3.2-3.2.2/docker-compose.yml
+++ b/13-3.2-3.2.2/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3"
+services:
+  postgis:
+    image: pgrouting/pgrouting:13-3.2-3.2.2
+    ports:
+      - "5432:5432"
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_PASSWORD=postgres
+volumes:
+  db-data:

--- a/13-3.2-3.2.2/extra/Dockerfile
+++ b/13-3.2-3.2.2/extra/Dockerfile
@@ -1,0 +1,44 @@
+FROM pgrouting/pgrouting:13-3.2-3.2.2
+
+ENV OSM2PGROUTING_VERSION 2.3.8
+
+RUN apt update \
+ && apt install -y \
+        libpqxx-6.2 \
+ && apt install -y \
+        build-essential \
+        cmake \
+        wget \
+        libboost-program-options-dev \
+        libexpat1 \
+        libexpat-dev \
+        libosmium2-dev \
+        libpqxx-dev \
+        zlib1g-dev \
+ && cd /usr/local/src \
+ && wget https://github.com/pgRouting/osm2pgrouting/archive/v${OSM2PGROUTING_VERSION}.tar.gz \
+ && tar xvf v${OSM2PGROUTING_VERSION}.tar.gz \
+ && cd osm2pgrouting-${OSM2PGROUTING_VERSION} \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd ../tools/osmium/ \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd /usr/local/src \
+ && rm -rf ./* \
+ && apt purge -y --autoremove \
+        build-essential \
+        cmake \
+        wget \
+        libexpat-dev \
+        libosmium2-dev \
+        libpqxx-dev \
+        zlib1g-dev \
+ && apt autoremove -y \
+ && rm -rf /var/lib/apt/lists/*

--- a/13-3.2-3.3.2/Dockerfile
+++ b/13-3.2-3.3.2/Dockerfile
@@ -1,0 +1,54 @@
+FROM postgis/postgis:13-3.2
+
+LABEL maintainer="pgRouting Project - https://pgrouting.net"
+
+ENV PGROUTING_VERSION 3.3.2
+ENV PGROUTING_SHA256 d5558cd419c8d46bdc958064cb97f963d1ea793866414c025906ec15033512ed
+
+RUN set -ex \
+ && apt update \
+ && apt install -y \
+        libboost-atomic1.67.0 \
+        libboost-chrono1.67.0 \
+        libboost-graph1.67.0 \
+        libboost-date-time1.67.0 \
+        libboost-program-options1.67.0 \
+        libboost-system1.67.0 \
+        libboost-thread1.67.0 \
+        libcgal13 \
+ && apt install -y \
+        build-essential \
+        cmake \
+        wget \
+        libboost-graph-dev \
+        libcgal-dev \
+        libpq-dev \
+        postgresql-server-dev-${PG_MAJOR} \
+ && wget -O pgrouting.tar.gz "https://github.com/pgRouting/pgrouting/archive/v${PGROUTING_VERSION}.tar.gz" \
+ && echo "$PGROUTING_SHA256 *pgrouting.tar.gz" | sha256sum -c - \
+ && mkdir -p /usr/src/pgrouting \
+ && tar \
+        --extract \
+        --file pgrouting.tar.gz \
+        --directory /usr/src/pgrouting \
+        --strip-components 1 \
+ && rm pgrouting.tar.gz \
+ && cd /usr/src/pgrouting \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd / \
+ && rm -rf /usr/src/pgrouting \
+ && apt-mark manual postgresql-13 \
+ && apt purge -y --autoremove \
+        build-essential \
+        cmake \
+        wget \
+        libcgal-dev \
+        libpq-dev \
+        libboost-graph-dev \
+        postgresql-server-dev-${PG_MAJOR} \
+ && rm -rf /var/lib/apt/lists/*
+RUN rm /docker-entrypoint-initdb.d/10_postgis.sh

--- a/13-3.2-3.3.2/README.md
+++ b/13-3.2-3.3.2/README.md
@@ -1,0 +1,3 @@
+# pgRouting 3.3.2 (pg13)
+
+pgRouting Docker image (version 3.3.2) built over [Postgres 13/PostGIS 3.2](https://hub.docker.com/r/postgis/postgis) and dependencies.

--- a/13-3.2-3.3.2/docker-compose.yml
+++ b/13-3.2-3.3.2/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3"
+services:
+  postgis:
+    image: pgrouting/pgrouting:13-3.2-3.3.2
+    ports:
+      - "5432:5432"
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_PASSWORD=postgres
+volumes:
+  db-data:

--- a/13-3.2-3.3.2/extra/Dockerfile
+++ b/13-3.2-3.3.2/extra/Dockerfile
@@ -1,0 +1,44 @@
+FROM pgrouting/pgrouting:13-3.2-3.3.2
+
+ENV OSM2PGROUTING_VERSION 2.3.8
+
+RUN apt update \
+ && apt install -y \
+        libpqxx-6.2 \
+ && apt install -y \
+        build-essential \
+        cmake \
+        wget \
+        libboost-program-options-dev \
+        libexpat1 \
+        libexpat-dev \
+        libosmium2-dev \
+        libpqxx-dev \
+        zlib1g-dev \
+ && cd /usr/local/src \
+ && wget https://github.com/pgRouting/osm2pgrouting/archive/v${OSM2PGROUTING_VERSION}.tar.gz \
+ && tar xvf v${OSM2PGROUTING_VERSION}.tar.gz \
+ && cd osm2pgrouting-${OSM2PGROUTING_VERSION} \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd ../tools/osmium/ \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd /usr/local/src \
+ && rm -rf ./* \
+ && apt purge -y --autoremove \
+        build-essential \
+        cmake \
+        wget \
+        libexpat-dev \
+        libosmium2-dev \
+        libpqxx-dev \
+        zlib1g-dev \
+ && apt autoremove -y \
+ && rm -rf /var/lib/apt/lists/*

--- a/14-3.2-3.0.6/Dockerfile
+++ b/14-3.2-3.0.6/Dockerfile
@@ -1,0 +1,54 @@
+FROM postgis/postgis:14-3.2
+
+LABEL maintainer="pgRouting Project - https://pgrouting.net"
+
+ENV PGROUTING_VERSION 3.0.6
+ENV PGROUTING_SHA256 9852e1e8f2da9137fb6120acee05dfb8edcff00bf06ff40a61291d91e84c69e9
+
+RUN set -ex \
+ && apt update \
+ && apt install -y \
+        libboost-atomic1.67.0 \
+        libboost-chrono1.67.0 \
+        libboost-graph1.67.0 \
+        libboost-date-time1.67.0 \
+        libboost-program-options1.67.0 \
+        libboost-system1.67.0 \
+        libboost-thread1.67.0 \
+        libcgal13 \
+ && apt install -y \
+        build-essential \
+        cmake \
+        wget \
+        libboost-graph-dev \
+        libcgal-dev \
+        libpq-dev \
+        postgresql-server-dev-${PG_MAJOR} \
+ && wget -O pgrouting.tar.gz "https://github.com/pgRouting/pgrouting/archive/v${PGROUTING_VERSION}.tar.gz" \
+ && echo "$PGROUTING_SHA256 *pgrouting.tar.gz" | sha256sum -c - \
+ && mkdir -p /usr/src/pgrouting \
+ && tar \
+        --extract \
+        --file pgrouting.tar.gz \
+        --directory /usr/src/pgrouting \
+        --strip-components 1 \
+ && rm pgrouting.tar.gz \
+ && cd /usr/src/pgrouting \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd / \
+ && rm -rf /usr/src/pgrouting \
+ && apt-mark manual postgresql-14 \
+ && apt purge -y --autoremove \
+        build-essential \
+        cmake \
+        wget \
+        libcgal-dev \
+        libpq-dev \
+        libboost-graph-dev \
+        postgresql-server-dev-${PG_MAJOR} \
+ && rm -rf /var/lib/apt/lists/*
+RUN rm /docker-entrypoint-initdb.d/10_postgis.sh

--- a/14-3.2-3.0.6/README.md
+++ b/14-3.2-3.0.6/README.md
@@ -1,0 +1,3 @@
+# pgRouting 3.0.6 (pg14)
+
+pgRouting Docker image (version 3.0.6) built over [Postgres 14/PostGIS 3.2](https://hub.docker.com/r/postgis/postgis) and dependencies.

--- a/14-3.2-3.0.6/docker-compose.yml
+++ b/14-3.2-3.0.6/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3"
+services:
+  postgis:
+    image: pgrouting/pgrouting:14-3.2-3.0.6
+    ports:
+      - "5432:5432"
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_PASSWORD=postgres
+volumes:
+  db-data:

--- a/14-3.2-3.0.6/extra/Dockerfile
+++ b/14-3.2-3.0.6/extra/Dockerfile
@@ -1,0 +1,44 @@
+FROM pgrouting/pgrouting:14-3.2-3.0.6
+
+ENV OSM2PGROUTING_VERSION 2.3.8
+
+RUN apt update \
+ && apt install -y \
+        libpqxx-6.2 \
+ && apt install -y \
+        build-essential \
+        cmake \
+        wget \
+        libboost-program-options-dev \
+        libexpat1 \
+        libexpat-dev \
+        libosmium2-dev \
+        libpqxx-dev \
+        zlib1g-dev \
+ && cd /usr/local/src \
+ && wget https://github.com/pgRouting/osm2pgrouting/archive/v${OSM2PGROUTING_VERSION}.tar.gz \
+ && tar xvf v${OSM2PGROUTING_VERSION}.tar.gz \
+ && cd osm2pgrouting-${OSM2PGROUTING_VERSION} \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd ../tools/osmium/ \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd /usr/local/src \
+ && rm -rf ./* \
+ && apt purge -y --autoremove \
+        build-essential \
+        cmake \
+        wget \
+        libexpat-dev \
+        libosmium2-dev \
+        libpqxx-dev \
+        zlib1g-dev \
+ && apt autoremove -y \
+ && rm -rf /var/lib/apt/lists/*

--- a/14-3.2-3.1.4/Dockerfile
+++ b/14-3.2-3.1.4/Dockerfile
@@ -1,0 +1,54 @@
+FROM postgis/postgis:14-3.2
+
+LABEL maintainer="pgRouting Project - https://pgrouting.net"
+
+ENV PGROUTING_VERSION 3.1.4
+ENV PGROUTING_SHA256 dcd05817b187e5c3f0cb741148db230a5f8d114b9738b6395057a9473b816842
+
+RUN set -ex \
+ && apt update \
+ && apt install -y \
+        libboost-atomic1.67.0 \
+        libboost-chrono1.67.0 \
+        libboost-graph1.67.0 \
+        libboost-date-time1.67.0 \
+        libboost-program-options1.67.0 \
+        libboost-system1.67.0 \
+        libboost-thread1.67.0 \
+        libcgal13 \
+ && apt install -y \
+        build-essential \
+        cmake \
+        wget \
+        libboost-graph-dev \
+        libcgal-dev \
+        libpq-dev \
+        postgresql-server-dev-${PG_MAJOR} \
+ && wget -O pgrouting.tar.gz "https://github.com/pgRouting/pgrouting/archive/v${PGROUTING_VERSION}.tar.gz" \
+ && echo "$PGROUTING_SHA256 *pgrouting.tar.gz" | sha256sum -c - \
+ && mkdir -p /usr/src/pgrouting \
+ && tar \
+        --extract \
+        --file pgrouting.tar.gz \
+        --directory /usr/src/pgrouting \
+        --strip-components 1 \
+ && rm pgrouting.tar.gz \
+ && cd /usr/src/pgrouting \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd / \
+ && rm -rf /usr/src/pgrouting \
+ && apt-mark manual postgresql-14 \
+ && apt purge -y --autoremove \
+        build-essential \
+        cmake \
+        wget \
+        libcgal-dev \
+        libpq-dev \
+        libboost-graph-dev \
+        postgresql-server-dev-${PG_MAJOR} \
+ && rm -rf /var/lib/apt/lists/*
+RUN rm /docker-entrypoint-initdb.d/10_postgis.sh

--- a/14-3.2-3.1.4/README.md
+++ b/14-3.2-3.1.4/README.md
@@ -1,0 +1,3 @@
+# pgRouting 3.1.4 (pg14)
+
+pgRouting Docker image (version 3.1.4) built over [Postgres 14/PostGIS 3.2](https://hub.docker.com/r/postgis/postgis) and dependencies.

--- a/14-3.2-3.1.4/docker-compose.yml
+++ b/14-3.2-3.1.4/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3"
+services:
+  postgis:
+    image: pgrouting/pgrouting:14-3.2-3.1.4
+    ports:
+      - "5432:5432"
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_PASSWORD=postgres
+volumes:
+  db-data:

--- a/14-3.2-3.1.4/extra/Dockerfile
+++ b/14-3.2-3.1.4/extra/Dockerfile
@@ -1,0 +1,44 @@
+FROM pgrouting/pgrouting:14-3.2-3.1.4
+
+ENV OSM2PGROUTING_VERSION 2.3.8
+
+RUN apt update \
+ && apt install -y \
+        libpqxx-6.2 \
+ && apt install -y \
+        build-essential \
+        cmake \
+        wget \
+        libboost-program-options-dev \
+        libexpat1 \
+        libexpat-dev \
+        libosmium2-dev \
+        libpqxx-dev \
+        zlib1g-dev \
+ && cd /usr/local/src \
+ && wget https://github.com/pgRouting/osm2pgrouting/archive/v${OSM2PGROUTING_VERSION}.tar.gz \
+ && tar xvf v${OSM2PGROUTING_VERSION}.tar.gz \
+ && cd osm2pgrouting-${OSM2PGROUTING_VERSION} \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd ../tools/osmium/ \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd /usr/local/src \
+ && rm -rf ./* \
+ && apt purge -y --autoremove \
+        build-essential \
+        cmake \
+        wget \
+        libexpat-dev \
+        libosmium2-dev \
+        libpqxx-dev \
+        zlib1g-dev \
+ && apt autoremove -y \
+ && rm -rf /var/lib/apt/lists/*

--- a/14-3.2-3.2.2/Dockerfile
+++ b/14-3.2-3.2.2/Dockerfile
@@ -1,0 +1,54 @@
+FROM postgis/postgis:14-3.2
+
+LABEL maintainer="pgRouting Project - https://pgrouting.net"
+
+ENV PGROUTING_VERSION 3.2.2
+ENV PGROUTING_SHA256 40f67ab944b5a7d91d4eb610cba3ed34a83daf51bb569c75b582f8e88efb72de
+
+RUN set -ex \
+ && apt update \
+ && apt install -y \
+        libboost-atomic1.67.0 \
+        libboost-chrono1.67.0 \
+        libboost-graph1.67.0 \
+        libboost-date-time1.67.0 \
+        libboost-program-options1.67.0 \
+        libboost-system1.67.0 \
+        libboost-thread1.67.0 \
+        libcgal13 \
+ && apt install -y \
+        build-essential \
+        cmake \
+        wget \
+        libboost-graph-dev \
+        libcgal-dev \
+        libpq-dev \
+        postgresql-server-dev-${PG_MAJOR} \
+ && wget -O pgrouting.tar.gz "https://github.com/pgRouting/pgrouting/archive/v${PGROUTING_VERSION}.tar.gz" \
+ && echo "$PGROUTING_SHA256 *pgrouting.tar.gz" | sha256sum -c - \
+ && mkdir -p /usr/src/pgrouting \
+ && tar \
+        --extract \
+        --file pgrouting.tar.gz \
+        --directory /usr/src/pgrouting \
+        --strip-components 1 \
+ && rm pgrouting.tar.gz \
+ && cd /usr/src/pgrouting \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd / \
+ && rm -rf /usr/src/pgrouting \
+ && apt-mark manual postgresql-14 \
+ && apt purge -y --autoremove \
+        build-essential \
+        cmake \
+        wget \
+        libcgal-dev \
+        libpq-dev \
+        libboost-graph-dev \
+        postgresql-server-dev-${PG_MAJOR} \
+ && rm -rf /var/lib/apt/lists/*
+RUN rm /docker-entrypoint-initdb.d/10_postgis.sh

--- a/14-3.2-3.2.2/README.md
+++ b/14-3.2-3.2.2/README.md
@@ -1,0 +1,3 @@
+# pgRouting 3.2.2 (pg14)
+
+pgRouting Docker image (version 3.2.2) built over [Postgres 14/PostGIS 3.2](https://hub.docker.com/r/postgis/postgis) and dependencies.

--- a/14-3.2-3.2.2/docker-compose.yml
+++ b/14-3.2-3.2.2/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3"
+services:
+  postgis:
+    image: pgrouting/pgrouting:14-3.2-3.2.2
+    ports:
+      - "5432:5432"
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_PASSWORD=postgres
+volumes:
+  db-data:

--- a/14-3.2-3.2.2/extra/Dockerfile
+++ b/14-3.2-3.2.2/extra/Dockerfile
@@ -1,0 +1,44 @@
+FROM pgrouting/pgrouting:14-3.2-3.2.2
+
+ENV OSM2PGROUTING_VERSION 2.3.8
+
+RUN apt update \
+ && apt install -y \
+        libpqxx-6.2 \
+ && apt install -y \
+        build-essential \
+        cmake \
+        wget \
+        libboost-program-options-dev \
+        libexpat1 \
+        libexpat-dev \
+        libosmium2-dev \
+        libpqxx-dev \
+        zlib1g-dev \
+ && cd /usr/local/src \
+ && wget https://github.com/pgRouting/osm2pgrouting/archive/v${OSM2PGROUTING_VERSION}.tar.gz \
+ && tar xvf v${OSM2PGROUTING_VERSION}.tar.gz \
+ && cd osm2pgrouting-${OSM2PGROUTING_VERSION} \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd ../tools/osmium/ \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd /usr/local/src \
+ && rm -rf ./* \
+ && apt purge -y --autoremove \
+        build-essential \
+        cmake \
+        wget \
+        libexpat-dev \
+        libosmium2-dev \
+        libpqxx-dev \
+        zlib1g-dev \
+ && apt autoremove -y \
+ && rm -rf /var/lib/apt/lists/*

--- a/14-3.2-3.3.2/Dockerfile
+++ b/14-3.2-3.3.2/Dockerfile
@@ -1,0 +1,54 @@
+FROM postgis/postgis:14-3.2
+
+LABEL maintainer="pgRouting Project - https://pgrouting.net"
+
+ENV PGROUTING_VERSION 3.3.2
+ENV PGROUTING_SHA256 d5558cd419c8d46bdc958064cb97f963d1ea793866414c025906ec15033512ed
+
+RUN set -ex \
+ && apt update \
+ && apt install -y \
+        libboost-atomic1.67.0 \
+        libboost-chrono1.67.0 \
+        libboost-graph1.67.0 \
+        libboost-date-time1.67.0 \
+        libboost-program-options1.67.0 \
+        libboost-system1.67.0 \
+        libboost-thread1.67.0 \
+        libcgal13 \
+ && apt install -y \
+        build-essential \
+        cmake \
+        wget \
+        libboost-graph-dev \
+        libcgal-dev \
+        libpq-dev \
+        postgresql-server-dev-${PG_MAJOR} \
+ && wget -O pgrouting.tar.gz "https://github.com/pgRouting/pgrouting/archive/v${PGROUTING_VERSION}.tar.gz" \
+ && echo "$PGROUTING_SHA256 *pgrouting.tar.gz" | sha256sum -c - \
+ && mkdir -p /usr/src/pgrouting \
+ && tar \
+        --extract \
+        --file pgrouting.tar.gz \
+        --directory /usr/src/pgrouting \
+        --strip-components 1 \
+ && rm pgrouting.tar.gz \
+ && cd /usr/src/pgrouting \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd / \
+ && rm -rf /usr/src/pgrouting \
+ && apt-mark manual postgresql-14 \
+ && apt purge -y --autoremove \
+        build-essential \
+        cmake \
+        wget \
+        libcgal-dev \
+        libpq-dev \
+        libboost-graph-dev \
+        postgresql-server-dev-${PG_MAJOR} \
+ && rm -rf /var/lib/apt/lists/*
+RUN rm /docker-entrypoint-initdb.d/10_postgis.sh

--- a/14-3.2-3.3.2/README.md
+++ b/14-3.2-3.3.2/README.md
@@ -1,0 +1,3 @@
+# pgRouting 3.3.2 (pg14)
+
+pgRouting Docker image (version 3.3.2) built over [Postgres 14/PostGIS 3.2](https://hub.docker.com/r/postgis/postgis) and dependencies.

--- a/14-3.2-3.3.2/docker-compose.yml
+++ b/14-3.2-3.3.2/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3"
+services:
+  postgis:
+    image: pgrouting/pgrouting:14-3.2-3.3.2
+    ports:
+      - "5432:5432"
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_PASSWORD=postgres
+volumes:
+  db-data:

--- a/14-3.2-3.3.2/extra/Dockerfile
+++ b/14-3.2-3.3.2/extra/Dockerfile
@@ -1,0 +1,44 @@
+FROM pgrouting/pgrouting:14-3.2-3.3.2
+
+ENV OSM2PGROUTING_VERSION 2.3.8
+
+RUN apt update \
+ && apt install -y \
+        libpqxx-6.2 \
+ && apt install -y \
+        build-essential \
+        cmake \
+        wget \
+        libboost-program-options-dev \
+        libexpat1 \
+        libexpat-dev \
+        libosmium2-dev \
+        libpqxx-dev \
+        zlib1g-dev \
+ && cd /usr/local/src \
+ && wget https://github.com/pgRouting/osm2pgrouting/archive/v${OSM2PGROUTING_VERSION}.tar.gz \
+ && tar xvf v${OSM2PGROUTING_VERSION}.tar.gz \
+ && cd osm2pgrouting-${OSM2PGROUTING_VERSION} \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd ../tools/osmium/ \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd /usr/local/src \
+ && rm -rf ./* \
+ && apt purge -y --autoremove \
+        build-essential \
+        cmake \
+        wget \
+        libexpat-dev \
+        libosmium2-dev \
+        libpqxx-dev \
+        zlib1g-dev \
+ && apt autoremove -y \
+ && rm -rf /var/lib/apt/lists/*

--- a/14-3.2-develop/Dockerfile
+++ b/14-3.2-develop/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgis/postgis:10-2.5
+FROM postgis/postgis:14-3.2
 
 LABEL maintainer="pgRouting Project - https://pgrouting.net"
 
@@ -7,14 +7,14 @@ ENV PGROUTING_GIT_HASH 7fcfc858d63fdc6060f9ba22138fbfb247672558
 
 RUN apt update \
  && apt install -y \
-        libboost-atomic1.62.0 \
-        libboost-chrono1.62.0 \
-        libboost-graph1.62.0 \
-        libboost-date-time1.62.0 \
-        libboost-program-options1.62.0 \
-        libboost-system1.62.0 \
-        libboost-thread1.62.0 \
-        libcgal12 \
+        libboost-atomic1.67.0 \
+        libboost-chrono1.67.0 \
+        libboost-graph1.67.0 \
+        libboost-date-time1.67.0 \
+        libboost-program-options1.67.0 \
+        libboost-system1.67.0 \
+        libboost-thread1.67.0 \
+        libcgal13 \
  && apt install -y \
         build-essential \
         cmake \

--- a/14-3.2-develop/README.md
+++ b/14-3.2-develop/README.md
@@ -1,0 +1,3 @@
+# pgRouting develop (pg14)
+
+pgRouting Docker image (version develop) built over [Postgres 14/PostGIS 3.2](https://hub.docker.com/r/postgis/postgis) and dependencies.

--- a/14-3.2-develop/docker-compose.yml
+++ b/14-3.2-develop/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3"
+services:
+  postgis:
+    image: pgrouting/pgrouting:14-3.2-develop
+    ports:
+      - "5432:5432"
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_PASSWORD=postgres
+volumes:
+  db-data:

--- a/14-3.2-develop/extra/Dockerfile
+++ b/14-3.2-develop/extra/Dockerfile
@@ -1,0 +1,44 @@
+FROM pgrouting/pgrouting:14-3.2-develop
+
+ENV OSM2PGROUTING_VERSION 2.3.8
+
+RUN apt update \
+ && apt install -y \
+        libpqxx-6.2 \
+ && apt install -y \
+        build-essential \
+        cmake \
+        wget \
+        libboost-program-options-dev \
+        libexpat1 \
+        libexpat-dev \
+        libosmium2-dev \
+        libpqxx-dev \
+        zlib1g-dev \
+ && cd /usr/local/src \
+ && wget https://github.com/pgRouting/osm2pgrouting/archive/v${OSM2PGROUTING_VERSION}.tar.gz \
+ && tar xvf v${OSM2PGROUTING_VERSION}.tar.gz \
+ && cd osm2pgrouting-${OSM2PGROUTING_VERSION} \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd ../tools/osmium/ \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd /usr/local/src \
+ && rm -rf ./* \
+ && apt purge -y --autoremove \
+        build-essential \
+        cmake \
+        wget \
+        libexpat-dev \
+        libosmium2-dev \
+        libpqxx-dev \
+        zlib1g-dev \
+ && apt autoremove -y \
+ && rm -rf /var/lib/apt/lists/*

--- a/14-3.2-main/Dockerfile
+++ b/14-3.2-main/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgis/postgis:10-2.5
+FROM postgis/postgis:14-3.2
 
 LABEL maintainer="pgRouting Project - https://pgrouting.net"
 
@@ -7,14 +7,14 @@ ENV PGROUTING_GIT_HASH 1d4f0a5c7ae815ff1ed31ae90171825a764dbf72
 
 RUN apt update \
  && apt install -y \
-        libboost-atomic1.62.0 \
-        libboost-chrono1.62.0 \
-        libboost-graph1.62.0 \
-        libboost-date-time1.62.0 \
-        libboost-program-options1.62.0 \
-        libboost-system1.62.0 \
-        libboost-thread1.62.0 \
-        libcgal12 \
+        libboost-atomic1.67.0 \
+        libboost-chrono1.67.0 \
+        libboost-graph1.67.0 \
+        libboost-date-time1.67.0 \
+        libboost-program-options1.67.0 \
+        libboost-system1.67.0 \
+        libboost-thread1.67.0 \
+        libcgal13 \
  && apt install -y \
         build-essential \
         cmake \

--- a/14-3.2-main/README.md
+++ b/14-3.2-main/README.md
@@ -1,0 +1,3 @@
+# pgRouting main (pg14)
+
+pgRouting Docker image (version main) built over [Postgres 14/PostGIS 3.2](https://hub.docker.com/r/postgis/postgis) and dependencies.

--- a/14-3.2-main/docker-compose.yml
+++ b/14-3.2-main/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3"
+services:
+  postgis:
+    image: pgrouting/pgrouting:14-3.2-main
+    ports:
+      - "5432:5432"
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_PASSWORD=postgres
+volumes:
+  db-data:

--- a/14-3.2-main/extra/Dockerfile
+++ b/14-3.2-main/extra/Dockerfile
@@ -1,0 +1,44 @@
+FROM pgrouting/pgrouting:14-3.2-main
+
+ENV OSM2PGROUTING_VERSION 2.3.8
+
+RUN apt update \
+ && apt install -y \
+        libpqxx-6.2 \
+ && apt install -y \
+        build-essential \
+        cmake \
+        wget \
+        libboost-program-options-dev \
+        libexpat1 \
+        libexpat-dev \
+        libosmium2-dev \
+        libpqxx-dev \
+        zlib1g-dev \
+ && cd /usr/local/src \
+ && wget https://github.com/pgRouting/osm2pgrouting/archive/v${OSM2PGROUTING_VERSION}.tar.gz \
+ && tar xvf v${OSM2PGROUTING_VERSION}.tar.gz \
+ && cd osm2pgrouting-${OSM2PGROUTING_VERSION} \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd ../tools/osmium/ \
+ && mkdir build \
+ && cd build \
+ && cmake .. \
+ && make \
+ && make install \
+ && cd /usr/local/src \
+ && rm -rf ./* \
+ && apt purge -y --autoremove \
+        build-essential \
+        cmake \
+        wget \
+        libexpat-dev \
+        libosmium2-dev \
+        libpqxx-dev \
+        zlib1g-dev \
+ && apt autoremove -y \
+ && rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -22,12 +22,24 @@ pgRouting Docker images.
 There are several versions available:
 
 - With pgRouting v3:
+  - [3.3.2 with Postgres 14 + PostGIS 3.2](14-3.2-3.3.2/). Docker image: `pgrouting/pgrouting:14-3.2-3.3.2`
+  - [3.3.2 with Postgres 13 + PostGIS 3.2](13-3.2-3.3.2/). Docker image: `pgrouting/pgrouting:13-3.2-3.3.2`
+  - [3.3.2 with Postgres 12 + PostGIS 3.2](12-3.2-3.3.2/). Docker image: `pgrouting/pgrouting:12-3.2-3.3.2`
+  - [3.3.2 with Postgres 11 + PostGIS 3.2](11-3.2-3.3.2/). Docker image: `pgrouting/pgrouting:11-3.2-3.3.2`
+  - [3.2.2 with Postgres 14 + PostGIS 3.2](14-3.2-3.2.2/). Docker image: `pgrouting/pgrouting:14-3.2-3.2.2`
+  - [3.2.2 with Postgres 13 + PostGIS 3.2](13-3.2-3.2.2/). Docker image: `pgrouting/pgrouting:13-3.2-3.2.2`
+  - [3.2.2 with Postgres 12 + PostGIS 3.2](12-3.2-3.2.2/). Docker image: `pgrouting/pgrouting:12-3.2-3.2.2`
+  - [3.2.2 with Postgres 11 + PostGIS 3.2](11-3.2-3.2.2/). Docker image: `pgrouting/pgrouting:11-3.2-3.2.2`
   - [3.2.1 with Postgres 13 + PostGIS 3.1](13-3.1-3.2.1/). Docker image: `pgrouting/pgrouting:13-3.1-3.2.1`
   - [3.2.1 with Postgres 12 + PostGIS 3.1](12-3.1-3.2.1/). Docker image: `pgrouting/pgrouting:12-3.1-3.2.1`
   - [3.2.1 with Postgres 11 + PostGIS 3.1](11-3.1-3.2.1/). Docker image: `pgrouting/pgrouting:11-3.1-3.2.1`
   - [3.2.0 with Postgres 13 + PostGIS 3.1](13-3.1-3.2.0/). Docker image: `pgrouting/pgrouting:13-3.1-3.2.0`
   - [3.2.0 with Postgres 12 + PostGIS 3.1](12-3.1-3.2.0/). Docker image: `pgrouting/pgrouting:12-3.1-3.2.0`
   - [3.2.0 with Postgres 11 + PostGIS 3.1](11-3.1-3.2.0/). Docker image: `pgrouting/pgrouting:11-3.1-3.2.0`
+  - [3.1.4 with Postgres 14 + PostGIS 3.2](14-3.2-3.1.4/). Docker image: `pgrouting/pgrouting:14-3.2-3.1.4`
+  - [3.1.4 with Postgres 13 + PostGIS 3.2](13-3.2-3.1.4/). Docker image: `pgrouting/pgrouting:13-3.2-3.1.4`
+  - [3.1.4 with Postgres 12 + PostGIS 3.2](12-3.2-3.1.4/). Docker image: `pgrouting/pgrouting:12-3.2-3.1.4`
+  - [3.1.4 with Postgres 11 + PostGIS 3.2](11-3.2-3.1.4/). Docker image: `pgrouting/pgrouting:11-3.2-3.1.4`
   - [3.1.3 with Postgres 13 + PostGIS 3.1](13-3.1-3.1.3/). Docker image: `pgrouting/pgrouting:13-3.1-3.1.3`
   - [3.1.3 with Postgres 12 + PostGIS 3.1](12-3.1-3.1.3/). Docker image: `pgrouting/pgrouting:12-3.1-3.1.3`
   - [3.1.3 with Postgres 11 + PostGIS 3.1](11-3.1-3.1.3/). Docker image: `pgrouting/pgrouting:11-3.1-3.1.3`
@@ -37,6 +49,10 @@ There are several versions available:
   - [3.1.0 with Postgres 13 + PostGIS 3.0](13-3.0-3.1.0/). Docker image: `pgrouting/pgrouting:13-3.0-3.1.0`
   - [3.1.0 with Postgres 12 + PostGIS 3.0](12-3.0-3.1.0/). Docker image: `pgrouting/pgrouting:12-3.0-3.1.0`
   - [3.1.0 with Postgres 11 + PostGIS 3.0](11-3.0-3.1.0/). Docker image: `pgrouting/pgrouting:11-3.0-3.1.0`
+  - [3.0.6 with Postgres 14 + PostGIS 3.2](14-3.2-3.0.6/). Docker image: `pgrouting/pgrouting:14-3.2-3.0.6`
+  - [3.0.6 with Postgres 13 + PostGIS 3.2](13-3.2-3.0.6/). Docker image: `pgrouting/pgrouting:13-3.2-3.0.6`
+  - [3.0.6 with Postgres 12 + PostGIS 3.2](12-3.2-3.0.6/). Docker image: `pgrouting/pgrouting:12-3.2-3.0.6`
+  - [3.0.6 with Postgres 11 + PostGIS 3.2](11-3.2-3.0.6/). Docker image: `pgrouting/pgrouting:11-3.2-3.0.6`
   - [3.0.1 with Postgres 12 + PostGIS 3.0](12-3.0-3.0.1/). Docker image: `pgrouting/pgrouting:12-3.0-3.0.1`
   - [3.0.1 with Postgres 11 + PostGIS 3.0](11-3.0-3.0.1/). Docker image: `pgrouting/pgrouting:11-3.0-3.0.1`
   - [3.0.0 with Postgres 12 + PostGIS 3.0](12-3.0-3.0.0/). Docker image: `pgrouting/pgrouting:12-3.0-3.0.0`
@@ -50,11 +66,13 @@ There are several versions available:
   - [2.6.1 with Postgres 11 + PostGIS 2.5](11-2.5-2.6.1/). Docker image: `pgrouting/pgrouting:11-2.5-2.6.1`
   - [2.6.1 with Postgres 10 + PostGIS 2.5](10-2.5-2.6.1/). Docker image: `pgrouting/pgrouting:10-2.5-2.6.1`
 - With pgRouting main branch (*):
-  - [main branch with Postgres 13 + PostGIS 3.1](13-3.0-develop/). Docker image: `pgrouting/pgrouting:13-3.0-main`
-  - [main branch with Postgres 12 + PostGIS 3.1](12-3.0-develop/). Docker image: `pgrouting/pgrouting:12-3.0-main`
-  - [main branch with Postgres 11 + PostGIS 2.5](11-2.5-develop/). Docker image: `pgrouting/pgrouting:11-2.5-main`
-  - [main branch with Postgres 10 + PostGIS 2.5](10-2.5-develop/). Docker image: `pgrouting/pgrouting:10-2.5-main`
+  - [main branch with Postgres 14 + PostGIS 3.2](14-3.2-main/). Docker image: `pgrouting/pgrouting:14-3.2-main`
+  - [main branch with Postgres 13 + PostGIS 3.0](13-3.0-main/). Docker image: `pgrouting/pgrouting:13-3.0-main`
+  - [main branch with Postgres 12 + PostGIS 3.0](12-3.0-main/). Docker image: `pgrouting/pgrouting:12-3.0-main`
+  - [main branch with Postgres 11 + PostGIS 2.5](11-2.5-main/). Docker image: `pgrouting/pgrouting:11-2.5-main`
+  - [main branch with Postgres 10 + PostGIS 2.5](10-2.5-main/). Docker image: `pgrouting/pgrouting:10-2.5-main`
 - With pgRouting develop branch (*):
+  - [develop branch with Postgres 14 + PostGIS 3.2](14-3.2-develop/). Docker image: `pgrouting/pgrouting:14-3.2-develop`
   - [develop branch with Postgres 13 + PostGIS 3.0](13-3.0-develop/). Docker image: `pgrouting/pgrouting:13-3.0-develop`
   - [develop branch with Postgres 12 + PostGIS 3.0](12-3.0-develop/). Docker image: `pgrouting/pgrouting:12-3.0-develop`
   - [develop branch with Postgres 11 + PostGIS 2.5](11-2.5-develop/). Docker image: `pgrouting/pgrouting:11-2.5-develop`

--- a/README.md
+++ b/README.md
@@ -49,18 +49,18 @@ There are several versions available:
   - [2.6.2 with Postgres 10 + PostGIS 2.5](10-2.5-2.6.2/). Docker image: `pgrouting/pgrouting:10-2.5-2.6.2`
   - [2.6.1 with Postgres 11 + PostGIS 2.5](11-2.5-2.6.1/). Docker image: `pgrouting/pgrouting:11-2.5-2.6.1`
   - [2.6.1 with Postgres 10 + PostGIS 2.5](10-2.5-2.6.1/). Docker image: `pgrouting/pgrouting:10-2.5-2.6.1`
-- With pgRouting master branch (*):
-  - [master branch with Postgres 13 + PostGIS 3.1](13-3.0-develop/). Docker image: `pgrouting/pgrouting:13-3.0-master`
-  - [master branch with Postgres 12 + PostGIS 3.1](12-3.0-develop/). Docker image: `pgrouting/pgrouting:12-3.0-master`
-  - [master branch with Postgres 11 + PostGIS 2.5](11-2.5-develop/). Docker image: `pgrouting/pgrouting:11-2.5-master`
-  - [master branch with Postgres 10 + PostGIS 2.5](10-2.5-develop/). Docker image: `pgrouting/pgrouting:10-2.5-master`
+- With pgRouting main branch (*):
+  - [main branch with Postgres 13 + PostGIS 3.1](13-3.0-develop/). Docker image: `pgrouting/pgrouting:13-3.0-main`
+  - [main branch with Postgres 12 + PostGIS 3.1](12-3.0-develop/). Docker image: `pgrouting/pgrouting:12-3.0-main`
+  - [main branch with Postgres 11 + PostGIS 2.5](11-2.5-develop/). Docker image: `pgrouting/pgrouting:11-2.5-main`
+  - [main branch with Postgres 10 + PostGIS 2.5](10-2.5-develop/). Docker image: `pgrouting/pgrouting:10-2.5-main`
 - With pgRouting develop branch (*):
   - [develop branch with Postgres 13 + PostGIS 3.0](13-3.0-develop/). Docker image: `pgrouting/pgrouting:13-3.0-develop`
   - [develop branch with Postgres 12 + PostGIS 3.0](12-3.0-develop/). Docker image: `pgrouting/pgrouting:12-3.0-develop`
   - [develop branch with Postgres 11 + PostGIS 2.5](11-2.5-develop/). Docker image: `pgrouting/pgrouting:11-2.5-develop`
   - [develop branch with Postgres 10 + PostGIS 2.5](10-2.5-develop/). Docker image: `pgrouting/pgrouting:10-2.5-develop`
 
-(*) If you want to use the last versions of develop or master branches you should consider to build the image by your own. See [here](#how-to-build-images) how to build images:
+(*) If you want to use the last versions of develop or main branches you should consider to build the image by your own. See [here](#how-to-build-images) how to build images:
 
 ## Tag roles
 
@@ -91,7 +91,7 @@ $ docker run --name pgrouting -p 5432:5432 pgrouting/pgrouting:12-3.0-2.6.3
 
 Building images:
 ```
-$ docker build -t pgrouting/pgrouting:13-3.0-master .
+$ docker build -t pgrouting/pgrouting:13-3.0-main .
 ```
 
 
@@ -111,26 +111,26 @@ CREATE DATABASE
 
 postgres@localhost ~>\c test
 You are now connected to database "test" as user "postgres".
-postgres@localhost test>create extension postgis;                                          
+postgres@localhost test>create extension postgis;
 CREATE EXTENSION
 
 postgres@localhost test>create extension pgrouting ;
 CREATE EXTENSION
 
 postgres@localhost test>select version();
-                                               version                                                
+                                               version
 ------------------------------------------------------------------------------------------------------
  PostgreSQL 12.3 (Debian 12.3-1.pgdg100+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 8.3.0-6) 8.3.0, 64-bit
 (1 row)
 
 postgres@localhost test>select pgr_version();
-                pgr_version                
+                pgr_version
 -------------------------------------------
 3.1.0
 (1 row)
 
 postgres@localhost test>select postgis_full_version();
-                        postgis_full_version                                                                      
+                        postgis_full_version
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 ------------------------------
 POSTGIS="3.0.1 ec2a9aa" [EXTENSION] PGSQL="120" GEOS="3.7.1-CAPI-1.11.1 27a5e771" PROJ="Rel. 5.2.0, September 15th, 2018" LIBXML="2.9.4" LIBJSON="0.12.1" LIBPROTOBUF="1.3.1" WAGYU="0.4.3 (Internal)"

--- a/extra/Dockerfile.template
+++ b/extra/Dockerfile.template
@@ -1,6 +1,6 @@
 FROM pgrouting/pgrouting:%%PG_MAJOR%%-%%POSTGIS_VERSION%%-%%PGROUTING_VERSION%%
 
-ENV OSM2PGROUTING_VERSION 2.3.7
+ENV OSM2PGROUTING_VERSION 2.3.8
 
 RUN apt update \
  && apt install -y \

--- a/update.sh
+++ b/update.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Derived from https://github.com/docker-library/postgres/blob/master/update.sh
+# Derived from https://github.com/docker-library/postgres/blob/main/update.sh
 set -Eeuo pipefail
 
 cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
@@ -31,7 +31,7 @@ for version in "${versions[@]}"; do
 
     tag="${debianSuite[$postgresVersion]:-$defaultDebianSuite}"
     suite="${tag%%-slim}"
-    
+
     if [ "$suite" = "stretch" ]; then
       boostVersion="1.62.0"
       cdalVersion="12"
@@ -43,7 +43,7 @@ for version in "${versions[@]}"; do
     fi
 
     srcVersion="${pgroutingVersion}"
-    if [ "$pgroutingVersion" == "develop" ] || [ "$pgroutingVersion" == "master" ]; then
+    if [ "$pgroutingVersion" == "develop" ] || [ "$pgroutingVersion" == "main" ]; then
       srcSha256=""
       pgroutingGitHash="$(git ls-remote https://github.com/pgrouting/pgrouting.git heads/${pgroutingVersion} | awk '{ print $1}')"
     else
@@ -53,7 +53,7 @@ for version in "${versions[@]}"; do
     (
         set -x
         cp -p -r Dockerfile.template README.md.template docker-compose.yml.template extra "$version/"
-        if [ "$pgroutingVersion" == "develop" ] || [ "$pgroutingVersion" == "master" ]; then
+        if [ "$pgroutingVersion" == "develop" ] || [ "$pgroutingVersion" == "main" ]; then
           cp -p Dockerfile.develop.template "$version/Dockerfile.template"
         fi
         mv "$version/Dockerfile.template" "$version/Dockerfile"

--- a/update.sh
+++ b/update.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Derived from https://github.com/docker-library/postgres/blob/main/update.sh
+# Derived from https://github.com/docker-library/postgres/blob/master/update.sh
 set -Eeuo pipefail
 
 cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"


### PR DESCRIPTION
Changes proposed in this pull request:
- Upgraded osm2pgrouting to 2.3.8.
- Changed master -> main.
- Updated all main and develop branch images, and added postgresql-14
- Add pgrouting 3.0.6, 3.1.4, 3.2.2, 3.3.2 each with pg11, 12, 13, 14 and postgis-3.2

@pgRouting/admins
