### PR TITLE
Correct the website url.  Should be pgrouting.org not pgrouting.net

### DIFF
--- a/10-2.5-develop/Dockerfile
+++ b/10-2.5-develop/Dockerfile
@@ -1,6 +1,6 @@
 FROM postgis/postgis:10-2.5
 
-LABEL maintainer="pgRouting Project - https://pgrouting.net"
+LABEL maintainer="pgRouting Project - https://pgrouting.org"
 
 ENV PGROUTING_VERSION develop
 ENV PGROUTING_GIT_HASH fb48e16f2d3c0f11060d58fc8be36e9325db2f59

--- a/10-2.5-develop/Dockerfile.develop.template
+++ b/10-2.5-develop/Dockerfile.develop.template
@@ -1,6 +1,6 @@
 FROM postgis/postgis:%%PG_MAJOR%%-%%POSTGIS_VERSION%%
 
-LABEL maintainer="pgRouting Project - https://pgrouting.net"
+LABEL maintainer="pgRouting Project - https://pgrouting.org"
 
 ENV PGROUTING_VERSION %%PGROUTING_VERSION%%
 

--- a/10-2.5-master/Dockerfile
+++ b/10-2.5-master/Dockerfile
@@ -1,6 +1,6 @@
 FROM postgis/postgis:10-2.5
 
-LABEL maintainer="pgRouting Project - https://pgrouting.net"
+LABEL maintainer="pgRouting Project - https://pgrouting.org"
 
 ENV PGROUTING_VERSION master
 ENV PGROUTING_GIT_HASH 

--- a/11-2.5-develop/Dockerfile
+++ b/11-2.5-develop/Dockerfile
@@ -1,6 +1,6 @@
 FROM postgis/postgis:11-2.5
 
-LABEL maintainer="pgRouting Project - https://pgrouting.net"
+LABEL maintainer="pgRouting Project - https://pgrouting.org"
 
 ENV PGROUTING_VERSION develop
 ENV PGROUTING_GIT_HASH fb48e16f2d3c0f11060d58fc8be36e9325db2f59

--- a/11-2.5-master/Dockerfile
+++ b/11-2.5-master/Dockerfile
@@ -1,6 +1,6 @@
 FROM postgis/postgis:11-2.5
 
-LABEL maintainer="pgRouting Project - https://pgrouting.net"
+LABEL maintainer="pgRouting Project - https://pgrouting.org"
 
 ENV PGROUTING_VERSION master
 ENV PGROUTING_GIT_HASH 

--- a/11-3.0-3.0.0/Dockerfile
+++ b/11-3.0-3.0.0/Dockerfile
@@ -1,6 +1,6 @@
 FROM postgis/postgis:11-3.0
 
-LABEL maintainer="pgRouting Project - https://pgrouting.net"
+LABEL maintainer="pgRouting Project - https://pgrouting.org"
 
 ENV PGROUTING_VERSION 3.0.0
 ENV PGROUTING_SHA256 eecb6a634b7bfdba0640518053a514330d468d214a8225548917fbce8a41745f

--- a/11-3.0-3.0.1/Dockerfile
+++ b/11-3.0-3.0.1/Dockerfile
@@ -1,6 +1,6 @@
 FROM postgis/postgis:11-3.0
 
-LABEL maintainer="pgRouting Project - https://pgrouting.net"
+LABEL maintainer="pgRouting Project - https://pgrouting.org"
 
 ENV PGROUTING_VERSION 3.0.1
 ENV PGROUTING_SHA256 b8da69ebe2f46eb5ec2eb6dfc0d3960d26cedf7e2a509cf58f459c2fd0ae53b3

--- a/11-3.0-3.1.0/Dockerfile
+++ b/11-3.0-3.1.0/Dockerfile
@@ -1,6 +1,6 @@
 FROM postgis/postgis:11-3.0
 
-LABEL maintainer="pgRouting Project - https://pgrouting.net"
+LABEL maintainer="pgRouting Project - https://pgrouting.org"
 
 ENV PGROUTING_VERSION 3.1.0
 ENV PGROUTING_SHA256 0471970338e38730092b39c8e87fde83e3100c471d856de24111005f6a91d481

--- a/11-3.0-3.1.1/Dockerfile
+++ b/11-3.0-3.1.1/Dockerfile
@@ -1,6 +1,6 @@
 FROM postgis/postgis:11-3.0
 
-LABEL maintainer="pgRouting Project - https://pgrouting.net"
+LABEL maintainer="pgRouting Project - https://pgrouting.org"
 
 ENV PGROUTING_VERSION 3.1.1
 ENV PGROUTING_SHA256 b32e50269c79d65cb31bc611473c2ff0f9948b1a15dcaeef077ffcdfbd1c2730

--- a/11-3.1-3.1.3/Dockerfile
+++ b/11-3.1-3.1.3/Dockerfile
@@ -1,6 +1,6 @@
 FROM postgis/postgis:11-3.1
 
-LABEL maintainer="pgRouting Project - https://pgrouting.net"
+LABEL maintainer="pgRouting Project - https://pgrouting.org"
 
 ENV PGROUTING_VERSION 3.1.3
 ENV PGROUTING_SHA256 54b58e8c4ac997d130e894f6311a28238258b224bb824b83f5bfa0fb4ee79c60

--- a/11-3.1-3.2.0/Dockerfile
+++ b/11-3.1-3.2.0/Dockerfile
@@ -1,6 +1,6 @@
 FROM postgis/postgis:11-3.1
 
-LABEL maintainer="pgRouting Project - https://pgrouting.net"
+LABEL maintainer="pgRouting Project - https://pgrouting.org"
 
 ENV PGROUTING_VERSION 3.2.0
 ENV PGROUTING_SHA256 5cf4d2147cf0897b5e2de9f1b526339abf293226c411882dba4901ba049092ab

--- a/11-3.1-3.2.1/Dockerfile
+++ b/11-3.1-3.2.1/Dockerfile
@@ -1,6 +1,6 @@
 FROM postgis/postgis:11-3.1
 
-LABEL maintainer="pgRouting Project - https://pgrouting.net"
+LABEL maintainer="pgRouting Project - https://pgrouting.org"
 
 ENV PGROUTING_VERSION 3.2.1
 ENV PGROUTING_SHA256 daeb7ba8703dde9b6cc84129eab64a0f2e1f819f00b9a9168a197c150583a5fd

--- a/12-3.0-3.0.0/Dockerfile
+++ b/12-3.0-3.0.0/Dockerfile
@@ -1,6 +1,6 @@
 FROM postgis/postgis:12-3.0
 
-LABEL maintainer="pgRouting Project - https://pgrouting.net"
+LABEL maintainer="pgRouting Project - https://pgrouting.org"
 
 ENV PGROUTING_VERSION 3.0.0
 ENV PGROUTING_SHA256 eecb6a634b7bfdba0640518053a514330d468d214a8225548917fbce8a41745f

--- a/12-3.0-3.0.1/Dockerfile
+++ b/12-3.0-3.0.1/Dockerfile
@@ -1,6 +1,6 @@
 FROM postgis/postgis:12-3.0
 
-LABEL maintainer="pgRouting Project - https://pgrouting.net"
+LABEL maintainer="pgRouting Project - https://pgrouting.org"
 
 ENV PGROUTING_VERSION 3.0.1
 ENV PGROUTING_SHA256 b8da69ebe2f46eb5ec2eb6dfc0d3960d26cedf7e2a509cf58f459c2fd0ae53b3

--- a/12-3.0-3.1.0/Dockerfile
+++ b/12-3.0-3.1.0/Dockerfile
@@ -1,6 +1,6 @@
 FROM postgis/postgis:12-3.0
 
-LABEL maintainer="pgRouting Project - https://pgrouting.net"
+LABEL maintainer="pgRouting Project - https://pgrouting.org"
 
 ENV PGROUTING_VERSION 3.1.0
 ENV PGROUTING_SHA256 0471970338e38730092b39c8e87fde83e3100c471d856de24111005f6a91d481

--- a/12-3.0-3.1.1/Dockerfile
+++ b/12-3.0-3.1.1/Dockerfile
@@ -1,6 +1,6 @@
 FROM postgis/postgis:12-3.0
 
-LABEL maintainer="pgRouting Project - https://pgrouting.net"
+LABEL maintainer="pgRouting Project - https://pgrouting.org"
 
 ENV PGROUTING_VERSION 3.1.1
 ENV PGROUTING_SHA256 b32e50269c79d65cb31bc611473c2ff0f9948b1a15dcaeef077ffcdfbd1c2730

--- a/12-3.0-develop/Dockerfile
+++ b/12-3.0-develop/Dockerfile
@@ -1,6 +1,6 @@
 FROM postgis/postgis:12-3.0
 
-LABEL maintainer="pgRouting Project - https://pgrouting.net"
+LABEL maintainer="pgRouting Project - https://pgrouting.org"
 
 ENV PGROUTING_VERSION develop
 ENV PGROUTING_GIT_HASH fb48e16f2d3c0f11060d58fc8be36e9325db2f59

--- a/12-3.0-master/Dockerfile
+++ b/12-3.0-master/Dockerfile
@@ -1,6 +1,6 @@
 FROM postgis/postgis:12-3.0
 
-LABEL maintainer="pgRouting Project - https://pgrouting.net"
+LABEL maintainer="pgRouting Project - https://pgrouting.org"
 
 ENV PGROUTING_VERSION master
 ENV PGROUTING_GIT_HASH 

--- a/12-3.1-3.1.3/Dockerfile
+++ b/12-3.1-3.1.3/Dockerfile
@@ -1,6 +1,6 @@
 FROM postgis/postgis:12-3.1
 
-LABEL maintainer="pgRouting Project - https://pgrouting.net"
+LABEL maintainer="pgRouting Project - https://pgrouting.org"
 
 ENV PGROUTING_VERSION 3.1.3
 ENV PGROUTING_SHA256 54b58e8c4ac997d130e894f6311a28238258b224bb824b83f5bfa0fb4ee79c60

--- a/12-3.1-3.2.0/Dockerfile
+++ b/12-3.1-3.2.0/Dockerfile
@@ -1,6 +1,6 @@
 FROM postgis/postgis:12-3.1
 
-LABEL maintainer="pgRouting Project - https://pgrouting.net"
+LABEL maintainer="pgRouting Project - https://pgrouting.org"
 
 ENV PGROUTING_VERSION 3.2.0
 ENV PGROUTING_SHA256 5cf4d2147cf0897b5e2de9f1b526339abf293226c411882dba4901ba049092ab

--- a/12-3.1-3.2.1/Dockerfile
+++ b/12-3.1-3.2.1/Dockerfile
@@ -1,6 +1,6 @@
 FROM postgis/postgis:12-3.1
 
-LABEL maintainer="pgRouting Project - https://pgrouting.net"
+LABEL maintainer="pgRouting Project - https://pgrouting.org"
 
 ENV PGROUTING_VERSION 3.2.1
 ENV PGROUTING_SHA256 daeb7ba8703dde9b6cc84129eab64a0f2e1f819f00b9a9168a197c150583a5fd

--- a/13-3.0-3.1.0/Dockerfile
+++ b/13-3.0-3.1.0/Dockerfile
@@ -1,6 +1,6 @@
 FROM postgis/postgis:13-3.0
 
-LABEL maintainer="pgRouting Project - https://pgrouting.net"
+LABEL maintainer="pgRouting Project - https://pgrouting.org"
 
 ENV PGROUTING_VERSION 3.1.0
 ENV PGROUTING_SHA256 0471970338e38730092b39c8e87fde83e3100c471d856de24111005f6a91d481

--- a/13-3.0-3.1.1/Dockerfile
+++ b/13-3.0-3.1.1/Dockerfile
@@ -1,6 +1,6 @@
 FROM postgis/postgis:13-3.0
 
-LABEL maintainer="pgRouting Project - https://pgrouting.net"
+LABEL maintainer="pgRouting Project - https://pgrouting.org"
 
 ENV PGROUTING_VERSION 3.1.1
 ENV PGROUTING_SHA256 b32e50269c79d65cb31bc611473c2ff0f9948b1a15dcaeef077ffcdfbd1c2730

--- a/13-3.0-develop/Dockerfile
+++ b/13-3.0-develop/Dockerfile
@@ -1,6 +1,6 @@
 FROM postgis/postgis:13-3.0
 
-LABEL maintainer="pgRouting Project - https://pgrouting.net"
+LABEL maintainer="pgRouting Project - https://pgrouting.org"
 
 ENV PGROUTING_VERSION develop
 ENV PGROUTING_GIT_HASH fb48e16f2d3c0f11060d58fc8be36e9325db2f59

--- a/13-3.0-master/Dockerfile
+++ b/13-3.0-master/Dockerfile
@@ -1,6 +1,6 @@
 FROM postgis/postgis:13-3.0
 
-LABEL maintainer="pgRouting Project - https://pgrouting.net"
+LABEL maintainer="pgRouting Project - https://pgrouting.org"
 
 ENV PGROUTING_VERSION master
 ENV PGROUTING_GIT_HASH 

--- a/13-3.1-3.1.3/Dockerfile
+++ b/13-3.1-3.1.3/Dockerfile
@@ -1,6 +1,6 @@
 FROM postgis/postgis:13-3.1
 
-LABEL maintainer="pgRouting Project - https://pgrouting.net"
+LABEL maintainer="pgRouting Project - https://pgrouting.org"
 
 ENV PGROUTING_VERSION 3.1.3
 ENV PGROUTING_SHA256 54b58e8c4ac997d130e894f6311a28238258b224bb824b83f5bfa0fb4ee79c60

--- a/13-3.1-3.2.0/Dockerfile
+++ b/13-3.1-3.2.0/Dockerfile
@@ -1,6 +1,6 @@
 FROM postgis/postgis:13-3.1
 
-LABEL maintainer="pgRouting Project - https://pgrouting.net"
+LABEL maintainer="pgRouting Project - https://pgrouting.org"
 
 ENV PGROUTING_VERSION 3.2.0
 ENV PGROUTING_SHA256 5cf4d2147cf0897b5e2de9f1b526339abf293226c411882dba4901ba049092ab

--- a/13-3.1-3.2.1/Dockerfile
+++ b/13-3.1-3.2.1/Dockerfile
@@ -1,6 +1,6 @@
 FROM postgis/postgis:13-3.1
 
-LABEL maintainer="pgRouting Project - https://pgrouting.net"
+LABEL maintainer="pgRouting Project - https://pgrouting.org"
 
 ENV PGROUTING_VERSION 3.2.1
 ENV PGROUTING_SHA256 daeb7ba8703dde9b6cc84129eab64a0f2e1f819f00b9a9168a197c150583a5fd

--- a/Dockerfile.develop.template
+++ b/Dockerfile.develop.template
@@ -1,6 +1,6 @@
 FROM postgis/postgis:%%PG_MAJOR%%-%%POSTGIS_VERSION%%
 
-LABEL maintainer="pgRouting Project - https://pgrouting.net"
+LABEL maintainer="pgRouting Project - https://pgrouting.org"
 
 ENV PGROUTING_VERSION %%PGROUTING_VERSION%%
 ENV PGROUTING_GIT_HASH %%PGROUTING_GIT_HASH%%

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,6 +1,6 @@
 FROM postgis/postgis:%%PG_MAJOR%%-%%POSTGIS_VERSION%%
 
-LABEL maintainer="pgRouting Project - https://pgrouting.net"
+LABEL maintainer="pgRouting Project - https://pgrouting.org"
 
 ENV PGROUTING_VERSION %%PGROUTING_VERSION%%
 ENV PGROUTING_SHA256 %%PGROUTING_SHA256%%


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
- change pgrouting.net  to pgrouting.org.  pgrouting.net does not exist.  pgrouting project site is pgrouting.org.
-
-

@pgRouting/admins
