### PR TITLE
Add GitHub Actions workflow for update PR

### DIFF
--- a/.github/workflows/update-pr.yml
+++ b/.github/workflows/update-pr.yml
@@ -2,8 +2,8 @@ name: Docker pgRouting update PR
 
 on:
   schedule:
-    # Run at 05:40 UTC
-    - cron: '40 5 * * *'
+    # Run at 00:00 UTC
+    - cron: '0 0 * * *'
   workflow_dispatch:
 
 defaults:

--- a/.github/workflows/update-pr.yml
+++ b/.github/workflows/update-pr.yml
@@ -1,0 +1,36 @@
+name: Docker pgRouting update PR
+
+on:
+  schedule:
+    # Run at 05:30 UTC
+    - cron: '30 5 * * *'
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  make-update:
+    name: Create update PR after make update
+    runs-on: ubuntu-24.04
+
+    steps:
+    - name: Checkout source
+      uses: actions/checkout@v4
+
+    - name: Make update
+      run: make update
+
+    - name: Check update
+      id: check-update
+      run: |
+        echo "::set-output name=updated::$(git status --porcelain | wc -l)"
+    - name: Create Pull Request
+      if: steps.check-update.outputs.updated > 0
+      uses: peter-evans/create-pull-request@v7
+      with:
+        commit-message: 'Update hashes and versions'
+        branch: update-hashes-and-versions
+        delete-branch: true
+        title: 'Update hashes and versions'

--- a/.github/workflows/update-pr.yml
+++ b/.github/workflows/update-pr.yml
@@ -2,8 +2,8 @@ name: Docker pgRouting update PR
 
 on:
   schedule:
-    # Run at 05:30 UTC
-    - cron: '30 5 * * *'
+    # Run at 05:40 UTC
+    - cron: '40 5 * * *'
   workflow_dispatch:
 
 defaults:

--- a/.github/workflows/update-pr.yml
+++ b/.github/workflows/update-pr.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Check update
       id: check-update
       run: |
-        echo "::set-output name=updated::$(git status --porcelain | wc -l)"
+        echo "updated=$(git status --porcelain | wc -l)" >> $GITHUB_OUTPUT
     - name: Create Pull Request
       if: steps.check-update.outputs.updated > 0
       uses: peter-evans/create-pull-request@v7


### PR DESCRIPTION
Supports #4, #22.

Changes proposed in this pull request:
- Create update PR when pgRouting `main`/`develop` branch's commit hashes or patch versions are updated
  - UTC 00:00 is used for scheduled daily job
    - Note that GitHub Action's scheduled job requires default branch
  - Example update PR is here:
    - https://github.com/sanak/docker-pgrouting/pull/2

@pgRouting/admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an automated process that creates pull requests to update project dependencies. This mechanism runs on a daily schedule and can also be triggered manually, ensuring the project stays current with the latest updates for improved maintainability and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->