### PR TITLE
Add pgrouting 3.8 to CI matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         postgres: [13, 14, 15, 16, 17]
         postgis: [3.5]
-        pgrouting: [3.6, 3.7, main, develop]
+        pgrouting: [3.6, 3.7, 3.8, main, develop]
 
     name: Build Docker image for ${{ matrix.postgres }}-${{ matrix.postgis }}-${{ matrix.pgrouting }}
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Changes proposed in this pull request:
- Add pgrouting 3.8 to CI matrix which was missing in PR #69 🙇💦

@pgRouting/admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Expanded Docker image builds and tests to include support for `pgrouting` version 3.8 in the automated workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->