### PR TITLE
Fix pg18 extra image CI failures by skipping tools/osmium build in update.sh

### DIFF
--- a/18-3.6-3.7/extra/Dockerfile
+++ b/18-3.6-3.7/extra/Dockerfile
@@ -24,12 +24,12 @@ RUN apt update \
  && cmake .. \
  && make \
  && make install \
- && cd ../tools/osmium/ \
- && mkdir build \
- && cd build \
- && cmake .. \
- && make \
- && make install \
+#  && cd ../tools/osmium/ \
+#  && mkdir build \
+#  && cd build \
+#  && cmake .. \
+#  && make \
+#  && make install \
  && cd /usr/local/src \
  && rm -rf ./* \
  && apt purge -y --autoremove \

--- a/18-3.6-3.8/extra/Dockerfile
+++ b/18-3.6-3.8/extra/Dockerfile
@@ -24,12 +24,12 @@ RUN apt update \
  && cmake .. \
  && make \
  && make install \
- && cd ../tools/osmium/ \
- && mkdir build \
- && cd build \
- && cmake .. \
- && make \
- && make install \
+#  && cd ../tools/osmium/ \
+#  && mkdir build \
+#  && cd build \
+#  && cmake .. \
+#  && make \
+#  && make install \
  && cd /usr/local/src \
  && rm -rf ./* \
  && apt purge -y --autoremove \

--- a/18-3.6-4.0/extra/Dockerfile
+++ b/18-3.6-4.0/extra/Dockerfile
@@ -24,12 +24,12 @@ RUN apt update \
  && cmake .. \
  && make \
  && make install \
- && cd ../tools/osmium/ \
- && mkdir build \
- && cd build \
- && cmake .. \
- && make \
- && make install \
+#  && cd ../tools/osmium/ \
+#  && mkdir build \
+#  && cd build \
+#  && cmake .. \
+#  && make \
+#  && make install \
  && cd /usr/local/src \
  && rm -rf ./* \
  && apt purge -y --autoremove \

--- a/18-3.6-develop/extra/Dockerfile
+++ b/18-3.6-develop/extra/Dockerfile
@@ -24,12 +24,12 @@ RUN apt update \
  && cmake .. \
  && make \
  && make install \
- && cd ../tools/osmium/ \
- && mkdir build \
- && cd build \
- && cmake .. \
- && make \
- && make install \
+#  && cd ../tools/osmium/ \
+#  && mkdir build \
+#  && cd build \
+#  && cmake .. \
+#  && make \
+#  && make install \
  && cd /usr/local/src \
  && rm -rf ./* \
  && apt purge -y --autoremove \

--- a/18-3.6-main/extra/Dockerfile
+++ b/18-3.6-main/extra/Dockerfile
@@ -24,12 +24,12 @@ RUN apt update \
  && cmake .. \
  && make \
  && make install \
- && cd ../tools/osmium/ \
- && mkdir build \
- && cd build \
- && cmake .. \
- && make \
- && make install \
+#  && cd ../tools/osmium/ \
+#  && mkdir build \
+#  && cd build \
+#  && cmake .. \
+#  && make \
+#  && make install \
  && cd /usr/local/src \
  && rm -rf ./* \
  && apt purge -y --autoremove \

--- a/update.sh
+++ b/update.sh
@@ -96,6 +96,11 @@ for version in "${versions[@]}"; do
         sed -i 's/%%PG_MAJOR%%/'"$postgresVersion"'/g; s/%%POSTGIS_VERSION%%/'"$postgisVersion"'/g; s/%%PGROUTING_VERSION%%/'"$pgroutingVersion"'/g;' "$version/docker-compose.yml"
         mv "$version/extra/Dockerfile.template" "$version/extra/Dockerfile"
         sed -i 's/%%PG_MAJOR%%/'"$postgresVersion"'/g; s/%%POSTGIS_VERSION%%/'"$postgisVersion"'/g; s/%%PGROUTING_VERSION%%/'"$pgroutingVersion"'/g; s/%%PQXX_VERSION%%/'"$pqxxVersion"'/g;' "$version/extra/Dockerfile"
+        # libosmium2-dev on Trixie has incompatible C++ API changes; skip tools/osmium build temporarily
+        # See: https://github.com/pgRouting/osm2pgrouting/issues/323
+        if [ "$suite" = "trixie" ]; then
+            sed -i '/\&\& cd \.\.\/tools\/osmium\//,/\&\& make install/ s/^ \+\&\& /#  \&\& /' "$version/extra/Dockerfile"
+        fi
         echo "$postgresVersion-$postgisVersion-$pgroutingVersion" > "$version/version.txt"
     )
 done


### PR DESCRIPTION
Fixes the regression introduced after #75 was merged.

Changes proposed in this pull request:
- Fix `update.sh` to comment out the `tools/osmium` build block when
  the target Debian suite is `trixie` (pg18)
- Regenerate `18-3.6-{3.7,3.8,4.0,develop,main}/extra/Dockerfile`
  with the osmium build skipped

## Background

PR #75 commit `9fe515a` manually commented out the `tools/osmium` build
lines in each `18-3.6-*/extra/Dockerfile` to work around the
`libosmium2-dev` C++ API incompatibility on Trixie:
- https://github.com/pgRouting/osm2pgrouting/issues/323

However, `update.sh` (and `extra/Dockerfile.template`) were not updated
at the same time. The subsequent nightly "Update hashes and versions" PRs
(#76, #78) ran `make update`, which regenerated those files from the
unchanged template — silently reverting the comments and causing all
`18-3.6-*` extra image builds to fail.

This PR moves the osmium skip into `update.sh` itself, so `make update`
produces the correct output and the fix survives future regenerations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Docker image build configuration updated across multiple release versions to disable compilation of a tool component, potentially reducing build time and image size.
  * Build automation script modified to consistently apply the updated compilation configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->